### PR TITLE
fixed ksnip/ksnip#253 issue with wrong image scaling on hdpi screen

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -176,7 +176,10 @@ void MainWindow::showCapture(const CaptureDto &capture)
 
 void MainWindow::loadCapture(const CaptureDto &capture)
 {
-	mKImageAnnotator->loadImage(capture.screenshot);
+	QPixmap image(capture.screenshot);
+	image.setDevicePixelRatio(1.0);
+	mKImageAnnotator->loadImage(image);
+	mKImageAnnotator->adjustSize();
 	if (capture.isCursorValid()) {
 		mKImageAnnotator->insertImageItem(capture.cursor.position, capture.cursor.image);
 	}


### PR DESCRIPTION
It seems like `devicePixelRatio` of `QPixmap` for some reason is not taken into account inside `kImageAnnotator`
here i tested this fix with 2x and 1x screen scale

for **2x**
[![here the video of the issue](https://img.youtube.com/vi/gnJ160TIU1k/0.jpg)](https://www.youtube.com/watch?v=gnJ160TIU1k)

for **1x**
[![here the video of the issue](https://img.youtube.com/vi/UkuXsKEGQ9o/0.jpg)](https://www.youtube.com/watch?v=UkuXsKEGQ9o)
