### PR TITLE
Fix: When 'Capture Save Location' is not set, ksnip fails to save

### DIFF
--- a/src/backend/ImageSaver.cpp
+++ b/src/backend/ImageSaver.cpp
@@ -49,7 +49,11 @@ QString ImageSaver::ensureFilenameHasFormat(const QString &path)
 {
     auto format = PathHelper::extractFormat(path);
     if(format.isEmpty()) {
-        return path + QStringLiteral(".") + mConfig->saveFormat();
+		auto defaultFormat = mConfig->saveFormat();
+		if (defaultFormat.isEmpty()) {
+			defaultFormat = QStringLiteral("png");
+		}
+        return path + QStringLiteral(".") + defaultFormat;
     }
     return path;
 }


### PR DESCRIPTION
I think I have found a bug in the app. 

**Repro**
1. Set 'Capture Save Location and Filename' to an empty value.
2. Capture a snip and press Ctrl+S.
3. Type in the file name and hit the Enter key. 
The app silently fails to save the file. 

**Reason**
It reads the 'SaveFormat' option from the config, which is formed by parsing 'Capture Save Location and Filename', so it gets an empty value in our case. mConfig->saveFormat() returns the empty string.

**Solution**
We can check if the mConfig->saveFormat() value is empty. If so, we can add the .png extension directly to the file name. This resolves the issue, and doesn't break any existing functionality.

---
P.S. I keep the 'Capture Save Location' value set to Empty because this allows the save file dialog to reuse the previously used folder. If you set it to a file name template without the path, or specify a file extension only, the app will always open the save dialog to the $HOME folder. This can be also changed, but I think that the proposed file change is enough.