### PR TITLE
Remember last used folder in the save file dialog

### DIFF
--- a/src/backend/ImageSaver.cpp
+++ b/src/backend/ImageSaver.cpp
@@ -49,7 +49,11 @@ QString ImageSaver::ensureFilenameHasFormat(const QString &path)
 {
     auto format = PathHelper::extractFormat(path);
     if(format.isEmpty()) {
-        return path + QStringLiteral(".") + mConfig->saveFormat();
+		auto defaultFormat = mConfig->saveFormat();
+		if (defaultFormat.isEmpty()) {
+			defaultFormat = QStringLiteral("png");
+		}
+        return path + QStringLiteral(".") + defaultFormat;
     }
     return path;
 }

--- a/src/backend/ImageSaver.cpp
+++ b/src/backend/ImageSaver.cpp
@@ -33,6 +33,10 @@ bool ImageSaver::save(const QImage &image, const QString &path)
 	if (!isSuccessful) {
 		qCritical("Unable to save file '%s'", qPrintable(fullPath));
 	}
+	else {
+		auto directory = PathHelper::extractPath(fullPath);
+		mConfig->setLastSaveDirectory(directory);
+	}
 	return isSuccessful;
 }
 

--- a/src/backend/config/KsnipConfig.cpp
+++ b/src/backend/config/KsnipConfig.cpp
@@ -144,6 +144,24 @@ void KsnipConfig::setSaveDirectory(const QString& path)
 	saveValue(KsnipConfigOptions::saveDirectoryString(), path);
 }
 
+QString KsnipConfig::lastSaveDirectory() const
+{
+	auto lastSaveDirectoryString = loadValue(KsnipConfigOptions::lastSaveDirectoryString(), QDir::homePath()).toString();
+	if (!lastSaveDirectoryString.isEmpty()) {
+		return lastSaveDirectoryString + QStringLiteral("/");
+    } else {
+		return {};
+    }
+}
+
+void KsnipConfig::setLastSaveDirectory(const QString& path)
+{
+    if (lastSaveDirectory() == path) {
+        return;
+    }
+	saveValue(KsnipConfigOptions::lastSaveDirectoryString(), path);
+}
+
 QString KsnipConfig::saveFilename() const
 {
 	auto defaultFilename = QStringLiteral("ksnip_$Y$M$D-$T");

--- a/src/backend/config/KsnipConfig.h
+++ b/src/backend/config/KsnipConfig.h
@@ -65,6 +65,9 @@ public:
 	virtual QString saveDirectory() const;
 	virtual void setSaveDirectory(const QString &path);
 
+	virtual QString lastSaveDirectory() const;
+	virtual void setLastSaveDirectory(const QString &path);
+
 	virtual QString saveFilename() const;
 	virtual void setSaveFilename(const QString &filename);
 

--- a/src/backend/config/KsnipConfigOptions.cpp
+++ b/src/backend/config/KsnipConfigOptions.cpp
@@ -64,6 +64,11 @@ QString KsnipConfigOptions::saveDirectoryString()
 	return applicationSectionString() + QStringLiteral("SaveDirectory");
 }
 
+QString KsnipConfigOptions::lastSaveDirectoryString()
+{
+	return applicationSectionString() + QStringLiteral("LastSaveDirectory");
+}
+
 QString KsnipConfigOptions::saveFilenameString()
 {
 	return applicationSectionString() + QStringLiteral("SaveFilename");

--- a/src/backend/config/KsnipConfigOptions.h
+++ b/src/backend/config/KsnipConfigOptions.h
@@ -34,6 +34,7 @@ public:
 	static QString positionString();
 	static QString captureModeString();
 	static QString saveDirectoryString();
+	static QString lastSaveDirectoryString();
 	static QString saveFilenameString();
 	static QString saveFormatString();
 	static QString useInstantSaveString();

--- a/src/backend/config/SavePathProvider.cpp
+++ b/src/backend/config/SavePathProvider.cpp
@@ -46,6 +46,13 @@ QString SavePathProvider::getFormat(const QString &format) const
 
 QString SavePathProvider::saveDirectory() const
 {
-    return PathHelper::replaceWildcards(mConfig->saveDirectory());
+	auto path = mConfig->saveDirectory();
+	if (path.isEmpty()) {
+		auto lastPath = mConfig->lastSaveDirectory();
+		if (!lastPath.isEmpty()) {
+			path = lastPath;
+		}
+	}
+    return PathHelper::replaceWildcards(path);
 }
 


### PR DESCRIPTION
If you specify only the file name in **Settings > Application > Capture save location and filename:**, the save dialog will always open to the home dir. 
![image](https://user-images.githubusercontent.com/1557252/75591683-6e915f00-5a91-11ea-8977-a724e4b2ced4.png)
This setup causes the app to create the following lines in the config file:
```
[Application]
SaveDirectory=
SaveFilename=ksnip_$Y$M$D-$T
SaveFormat=png
```

The changes in this commit add the ability to save the last directory selected to store the captures in the ksnip.conf file. Next time the user saves the capture, the app will read the saved path from the config file. If the SaveDirectory value is empty, QFileDialog will be opened to the last used folder. This is very useful when you have to work with more than just one default folder.