### PR TITLE
Fix env variables to support gnome appindicator

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,13 +14,12 @@ apps:
     command: ksnip
     common-id: ksnip
     environment:
-      # Correct the TMPDIR path for Chromium Framework/Electron to
-      # ensure libappindicator has readable resources
-      TMPDIR: $XDG_RUNTIME_DIR
       # Coerce XDG_CURRENT_DESKTOP to Unity so that App Indicators
       # are used and do not fall back to Notification Area applets
       # or disappear completely.
       XDG_CURRENT_DESKTOP: Unity:Unity7
+      # Set theme fix on gnome/gtk
+      QT_QPA_PLATFORMTHEME: gtk3
     desktop: share/applications/ksnip.desktop
     extensions: [kde-neon]
     plugs:


### PR DESCRIPTION
With the previous env variables the indicator icon was not showing in Gnome.
This PR fixes the issue by forcing gtk3 mode.