### PR TITLE
Add missing plugs to silence socket warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,11 @@ apps:
       - home
       - removable-media
       - unity7
+      - network
+      - network-manager-observe
+      - network-observe
+      - opengl
+      - system-observe
 
 parts:
   ksnip:


### PR DESCRIPTION
Should solve #312 
The following plugs are not auto-connected, so the user should be notified of the manual connection.
It might be possible to ask on the snapcraft forum for an auto-connection.
