### PR TITLE
Enable indicator via unity env variable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
     common-id: org.ksnip.ksnip
     environment:
       # Set theme fix on gnome/gtk
+      XDG_CURRENT_DESKTOP: Unity:Unity7:$XDG_CURRENT_DESKTOP
       QT_QPA_PLATFORMTHEME: gtk3
     desktop: share/applications/org.ksnip.ksnip.desktop
     extensions: [kde-neon]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ apps:
     common-id: org.ksnip.ksnip
     environment:
       # Set theme fix on gnome/gtk
-      XDG_CURRENT_DESKTOP: Unity:Unity7:$XDG_CURRENT_DESKTOP
+      XDG_CURRENT_DESKTOP: $XDG_CURRENT_DESKTOP:Unity:Unity7
       QT_QPA_PLATFORMTHEME: gtk3
     desktop: share/applications/org.ksnip.ksnip.desktop
     extensions: [kde-neon]


### PR DESCRIPTION
Fixes #445 
This PR enables the appindicator icon to show again.
Instead of overriding the XDG_CURRENT_DESKTOP it appends the Unity variable, so it should not break anything else.
In --edge we can test it on different distros/DEs