### PR TITLE
Add image rename functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(KSNIP_SRCS
 	${CMAKE_SOURCE_DIR}/src/gui/globalHotKeys/HotKeyMap.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/globalHotKeys/DummyKeyHandler.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/SaveOperation.cpp
+        ${CMAKE_SOURCE_DIR}/src/gui/operations/RenameOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/AddWatermarkOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/UpdateWatermarkOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/WatermarkImagePreparer.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ set(KSNIP_SRCS
 	${CMAKE_SOURCE_DIR}/src/gui/globalHotKeys/HotKeyMap.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/globalHotKeys/DummyKeyHandler.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/SaveOperation.cpp
-        ${CMAKE_SOURCE_DIR}/src/gui/operations/RenameOperation.cpp
+	${CMAKE_SOURCE_DIR}/src/gui/operations/RenameOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/AddWatermarkOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/UpdateWatermarkOperation.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/operations/WatermarkImagePreparer.cpp

--- a/src/common/dtos/RenameResultDto.h
+++ b/src/common/dtos/RenameResultDto.h
@@ -17,36 +17,19 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef KSNIP_RENAMEOPERATION_H
-#define KSNIP_RENAMEOPERATION_H
+#ifndef KSNIP_RENAMERESULTDTO_H
+#define KSNIP_RENAMERESULTDTO_H
 
-#include <QCoreApplication>
-#include <QFile>
-#include <QFileInfo>
-#include <QInputDialog>
+#include "FilePathDto.h"
 
-#include <utility>
-
-#include "NotifyOperation.h"
-#include "src/common/dtos/RenameResultDto.h"
-#include "src/gui/IToastService.h"
-
-class RenameOperation : public QObject
+struct RenameResultDto : public FilePathDto
 {
-		Q_OBJECT
-public:
-	RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService);
-	~RenameOperation() override = default;
-	RenameResultDto execute();
+    bool isSuccessful;
 
-private:
-	QString getNewFilename() const;
-	bool rename(const QString &newFilename);
-
-	QWidget* mParent;
-	QString mPathToImageSource;
-	QString mImageFilename;
-	IToastService *mToastService;
+    explicit RenameResultDto(bool isSuccessful, const QString &path) {
+	this->isSuccessful = isSuccessful;
+	this->path = path;
+    }
 };
 
-#endif //KSNIP_RENAMEOPERATION_H
+#endif //KSNIP_RENAMERESULTDTO_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -31,6 +31,7 @@ MainWindow::MainWindow(AbstractImageGrabber *imageGrabber, RunMode mode) :
 		mPrintPreviewAction(new QAction(this)),
 		mQuitAction(new QAction(this)),
 		mCopyPathAction(new QAction(this)),
+		mRenameAction(new QAction(this)),
 		mOpenDirectoryAction(new QAction(this)),
 		mSettingsAction(new QAction(this)),
 		mAboutAction(new QAction(this)),
@@ -127,6 +128,7 @@ MainWindow::~MainWindow()
     delete mPrintPreviewAction;
     delete mQuitAction;
     delete mCopyPathAction;
+    delete mRenameAction;
     delete mOpenDirectoryAction;
     delete mSettingsAction;
     delete mAboutAction;
@@ -289,6 +291,7 @@ void MainWindow::captureChanged()
 {
     mToolBar->setSaveActionEnabled(!mCaptureHandler->isSaved());
 	mCopyPathAction->setEnabled(mCaptureHandler->isPathValid());
+	mRenameAction->setEnabled(mCaptureHandler->isSaved());
 	mOpenDirectoryAction->setEnabled(mCaptureHandler->isPathValid());
 	mRemoveImageAction->setEnabled(mCaptureHandler->isPathValid());
 	updateApplicationTitle();
@@ -395,6 +398,9 @@ void MainWindow::initGui()
 	mCopyPathAction->setText(tr("Copy Path"));
 	connect(mCopyPathAction, &QAction::triggered, mCaptureHandler, &ICaptureHandler::copyPath);
 
+	mRenameAction->setText(tr("Rename"));
+	connect(mRenameAction, &QAction::triggered, mCaptureHandler, &ICaptureHandler::rename);
+
 	mOpenDirectoryAction->setText(tr("Open Directory"));
 	connect(mOpenDirectoryAction, &QAction::triggered, mCaptureHandler, &ICaptureHandler::openDirectory);
 
@@ -453,6 +459,7 @@ void MainWindow::initGui()
     menu->addSeparator();
     menu->addAction(mToolBar->copyToClipboardAction());
     menu->addAction(mCopyPathAction);
+    menu->addAction(mRenameAction);
     menu->addAction(mPasteAction);
     menu->addAction(mPasteEmbeddedAction);
 	menu->addSeparator();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -399,6 +399,7 @@ void MainWindow::initGui()
 	connect(mCopyPathAction, &QAction::triggered, mCaptureHandler, &ICaptureHandler::copyPath);
 
 	mRenameAction->setText(tr("Rename"));
+	mRenameAction->setShortcut(Qt::Key_F2);
 	connect(mRenameAction, &QAction::triggered, mCaptureHandler, &ICaptureHandler::rename);
 
 	mOpenDirectoryAction->setText(tr("Open Directory"));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -317,6 +317,7 @@ void MainWindow::setEnablements(bool enabled)
 	mSaveAsAction->setEnabled(enabled);
 	mPinAction->setEnabled(enabled);
 	mPasteEmbeddedAction->setEnabled(mClipboard->isPixmap() && mImageAnnotator->isVisible());
+	mRenameAction->setEnabled(enabled);
 }
 
 void MainWindow::loadSettings()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -85,6 +85,7 @@ private:
     QAction *mPrintPreviewAction;
     QAction *mQuitAction;
     QAction *mCopyPathAction;
+    QAction *mRenameAction;
     QAction *mOpenDirectoryAction;
     QAction *mSettingsAction;
     QAction *mAboutAction;

--- a/src/gui/captureHandler/CaptureTabStateHandler.cpp
+++ b/src/gui/captureHandler/CaptureTabStateHandler.cpp
@@ -65,6 +65,16 @@ void CaptureTabStateHandler::setSaveState(int index, const SaveResultDto &saveRe
 	}
 }
 
+void CaptureTabStateHandler::setRenameState(int index, const RenameResultDto &renameResult)
+{
+	auto tabState = getTabState(index);
+	if (!tabState.isNull() && renameResult.isSuccessful) {
+		tabState->path = renameResult.path;
+		tabState->filename = PathHelper::extractFilename(renameResult.path);
+		refreshTabInfo(index);
+	}
+}
+
 void CaptureTabStateHandler::tabMoved(int fromIndex, int toIndex)
 {
 	for (auto& state : mCaptureTabStates) {

--- a/src/gui/captureHandler/CaptureTabStateHandler.h
+++ b/src/gui/captureHandler/CaptureTabStateHandler.h
@@ -27,6 +27,7 @@
 #include "ICaptureTabStateHandler.h"
 #include "CaptureTabState.h"
 #include "src/common/dtos/SaveResultDto.h"
+#include "src/common/dtos/RenameResultDto.h"
 #include "src/common/helper/PathHelper.h"
 
 class CaptureTabStateHandler : public ICaptureTabStateHandler
@@ -41,6 +42,7 @@ public:
 	QString path(int index) override;
 	QString filename(int index) override;
 	void setSaveState(int index, const SaveResultDto &saveResult) override;
+	void setRenameState(int index, const RenameResultDto &renameResult) override;
 	int count() const override;
 	int currentTabIndex() const override;
 

--- a/src/gui/captureHandler/ICaptureHandler.h
+++ b/src/gui/captureHandler/ICaptureHandler.h
@@ -35,6 +35,7 @@ public:
 	virtual bool isPathValid() const = 0;
 	virtual void saveAs() = 0;
 	virtual void save() = 0;
+	virtual void rename() = 0;
 	virtual void copy() = 0;
 	virtual void copyPath() = 0;
 	virtual void openDirectory() = 0;

--- a/src/gui/captureHandler/ICaptureTabStateHandler.h
+++ b/src/gui/captureHandler/ICaptureTabStateHandler.h
@@ -23,6 +23,7 @@
 #include <QObject>
 
 struct SaveResultDto;
+struct RenameResultDto;
 
 class ICaptureTabStateHandler : public QObject
 {
@@ -36,6 +37,7 @@ public:
 	virtual QString path(int index) = 0;
 	virtual QString filename(int index) = 0;
 	virtual void setSaveState(int index, const SaveResultDto &saveResult) = 0;
+	virtual void setRenameState(int index, const RenameResultDto &renameResult) = 0;
 	virtual int count() const = 0;
 	virtual int currentTabIndex() const = 0;
 

--- a/src/gui/captureHandler/MultiCaptureHandler.cpp
+++ b/src/gui/captureHandler/MultiCaptureHandler.cpp
@@ -276,9 +276,9 @@ void MultiCaptureHandler::saveTab(int index)
 void MultiCaptureHandler::renameTab(int index)
 {
 	RenameOperation operation(mParent, mTabStateHandler->path(index), mTabStateHandler->filename(index), mToastService);
-	const auto saveResult = operation.execute();
-	if (saveResult.isSuccessful) {
-		mTabStateHandler->setSaveState(index, saveResult);
+	const auto renameResult = operation.execute();
+	if (renameResult.isSuccessful) {
+		mTabStateHandler->setRenameState(index, renameResult);
 		captureChanged();
 	}
 }

--- a/src/gui/captureHandler/MultiCaptureHandler.cpp
+++ b/src/gui/captureHandler/MultiCaptureHandler.cpp
@@ -32,6 +32,7 @@ MultiCaptureHandler::MultiCaptureHandler(IImageAnnotator *imageAnnotator, IToast
 	mDesktopService(mServiceLocator->desktopService()),
 	mSaveContextMenuAction(new TabContextMenuAction(this)),
 	mSaveAsContextMenuAction(new TabContextMenuAction(this)),
+	mRenameContextMenuAction(new TabContextMenuAction(this)),
 	mOpenDirectoryContextMenuAction(new TabContextMenuAction(this)),
 	mCopyPathToClipboardContextMenuAction(new TabContextMenuAction(this)),
 	mCopyToClipboardContextMenuAction(new TabContextMenuAction(this)),
@@ -60,6 +61,7 @@ MultiCaptureHandler::~MultiCaptureHandler()
 	delete mTabStateHandler;
 	delete mSaveContextMenuAction;
 	delete mSaveAsContextMenuAction;
+	delete mRenameContextMenuAction;
 	delete mOpenDirectoryContextMenuAction;
 	delete mCopyPathToClipboardContextMenuAction;
 	delete mCopyToClipboardContextMenuAction;
@@ -129,6 +131,11 @@ void MultiCaptureHandler::saveAs()
 void MultiCaptureHandler::save()
 {
 	saveTab(mTabStateHandler->currentTabIndex());
+}
+
+void MultiCaptureHandler::rename()
+{
+	renameTab(mTabStateHandler->currentTabIndex());
 }
 
 void MultiCaptureHandler::copy()
@@ -222,6 +229,8 @@ void MultiCaptureHandler::addTabContextMenuActions()
 	mSaveAsContextMenuAction->setText(tr("Save As"));
 	mSaveAsContextMenuAction->setIcon(IconLoader::load(QLatin1Literal("saveAs.svg")));
 
+	mRenameContextMenuAction->setText(tr("Rename"));
+
 	mOpenDirectoryContextMenuAction->setText(tr("Open Directory"));
 
 	mCopyToClipboardContextMenuAction->setText(tr("Copy"));
@@ -236,6 +245,7 @@ void MultiCaptureHandler::addTabContextMenuActions()
 
 	connect(mSaveContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::saveTab);
 	connect(mSaveAsContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::saveAsTab);
+	connect(mRenameContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::renameTab);
 	connect(mOpenDirectoryContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::openDirectoryTab);
 	connect(mCopyPathToClipboardContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::copyPathToClipboardTab);
 	connect(mCopyToClipboardContextMenuAction, &TabContextMenuAction::triggered, this, &MultiCaptureHandler::copyToClipboardTab);
@@ -243,6 +253,7 @@ void MultiCaptureHandler::addTabContextMenuActions()
 
 	auto actions = QList<QAction *>{mSaveContextMenuAction,
 									mSaveAsContextMenuAction,
+									mRenameContextMenuAction,
 									mOpenDirectoryContextMenuAction,
 									mCopyToClipboardContextMenuAction,
 									mCopyPathToClipboardContextMenuAction,
@@ -262,10 +273,21 @@ void MultiCaptureHandler::saveTab(int index)
 	saveAt(index, true);
 }
 
+void MultiCaptureHandler::renameTab(int index)
+{
+	RenameOperation operation(mParent, mTabStateHandler->path(index), mTabStateHandler->filename(index), mToastService);
+	const auto saveResult = operation.execute();
+	if (saveResult.isSuccessful) {
+		mTabStateHandler->setSaveState(index, saveResult);
+		captureChanged();
+	}
+}
+
 void MultiCaptureHandler::updateContextMenuActions(int index)
 {
 	auto isPathValid = mTabStateHandler->isPathValid(index);
 	mSaveContextMenuAction->setEnabled(!mTabStateHandler->isSaved(index));
+	mRenameContextMenuAction->setEnabled(mTabStateHandler->isSaved(index));
 	mOpenDirectoryContextMenuAction->setEnabled(isPathValid);
 	mCopyPathToClipboardContextMenuAction->setEnabled(isPathValid);
 	mDeleteImageContextMenuAction->setEnabled(isPathValid);

--- a/src/gui/captureHandler/MultiCaptureHandler.h
+++ b/src/gui/captureHandler/MultiCaptureHandler.h
@@ -27,7 +27,6 @@
 #include "src/gui/operations/SaveOperation.h"
 #include "src/gui/operations/RenameOperation.h"
 #include "src/gui/operations/DeleteImageOperation.h"
-#include "src/gui/operations/RenameOperation.h"
 #include "src/gui/IToastService.h"
 #include "src/gui/serviceLocator/IServiceLocator.h"
 #include "src/gui/imageAnnotator/IImageAnnotator.h"

--- a/src/gui/captureHandler/MultiCaptureHandler.h
+++ b/src/gui/captureHandler/MultiCaptureHandler.h
@@ -25,7 +25,9 @@
 #include "src/gui/captureHandler/TabContextMenuAction.h"
 #include "src/gui/operations/CanDiscardOperation.h"
 #include "src/gui/operations/SaveOperation.h"
+#include "src/gui/operations/RenameOperation.h"
 #include "src/gui/operations/DeleteImageOperation.h"
+#include "src/gui/operations/RenameOperation.h"
 #include "src/gui/IToastService.h"
 #include "src/gui/serviceLocator/IServiceLocator.h"
 #include "src/gui/imageAnnotator/IImageAnnotator.h"
@@ -48,6 +50,7 @@ public:
 	bool isPathValid() const override;
 	void saveAs() override;
 	void save() override;
+	void rename() override;
 	void copy() override;
 	void copyPath() override;
 	void openDirectory() override;
@@ -71,6 +74,7 @@ private:
 	IDesktopService *mDesktopService;
 	TabContextMenuAction *mSaveContextMenuAction;
 	TabContextMenuAction *mSaveAsContextMenuAction;
+	TabContextMenuAction *mRenameContextMenuAction;
 	TabContextMenuAction *mOpenDirectoryContextMenuAction;
 	TabContextMenuAction *mCopyPathToClipboardContextMenuAction;
 	TabContextMenuAction *mCopyToClipboardContextMenuAction;
@@ -88,6 +92,7 @@ private slots:
 	void annotatorConfigChanged();
 	void addTabContextMenuActions();
 	void saveAsTab(int index);
+	void renameTab(int index);
 	void saveTab(int index);
 	void openDirectoryTab(int index);
 	void updateContextMenuActions(int index);

--- a/src/gui/captureHandler/SingleCaptureHandler.cpp
+++ b/src/gui/captureHandler/SingleCaptureHandler.cpp
@@ -72,9 +72,9 @@ void SingleCaptureHandler::save()
 void SingleCaptureHandler::rename()
 {
 	RenameOperation operation(mParent, mPath, QFileInfo(mPath).fileName(), mToastService);
-	const auto saveResult = operation.execute();
-	if (saveResult.isSuccessful) {
-		mPath = saveResult.path;
+	const auto renameResult = operation.execute();
+	if (renameResult.isSuccessful) {
+		mPath = renameResult.path;
 		captureChanged();
 	}
 }

--- a/src/gui/captureHandler/SingleCaptureHandler.cpp
+++ b/src/gui/captureHandler/SingleCaptureHandler.cpp
@@ -69,6 +69,16 @@ void SingleCaptureHandler::save()
 	innerSave(true);
 }
 
+void SingleCaptureHandler::rename()
+{
+	RenameOperation operation(mParent, mPath, QFileInfo(mPath).fileName(), mToastService);
+	const auto saveResult = operation.execute();
+	if (saveResult.isSuccessful) {
+		mPath = saveResult.path;
+		captureChanged();
+	}
+}
+
 void SingleCaptureHandler::copy()
 {
 	auto image = mImageAnnotator->image();

--- a/src/gui/captureHandler/SingleCaptureHandler.h
+++ b/src/gui/captureHandler/SingleCaptureHandler.h
@@ -23,6 +23,7 @@
 #include "src/gui/captureHandler/ICaptureHandler.h"
 #include "src/gui/operations/CanDiscardOperation.h"
 #include "src/gui/operations/DeleteImageOperation.h"
+#include "src/gui/operations/RenameOperation.h"
 #include "src/gui/IToastService.h"
 #include "src/gui/serviceLocator/IServiceLocator.h"
 #include "src/gui/imageAnnotator/IImageAnnotator.h"
@@ -41,6 +42,7 @@ public:
 	bool isPathValid() const override;
 	void saveAs() override;
 	void save() override;
+	void rename() override;
 	void copy() override;
 	void copyPath() override;
 	void openDirectory() override;

--- a/src/gui/operations/RenameOperation.cpp
+++ b/src/gui/operations/RenameOperation.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Damir Porobic <damir.porobic@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "RenameOperation.h"
+
+#include <utility>
+
+RenameOperation::RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService)
+	: mParent(parent), mPathToImageSource(pathToImageSource), mImageFilename(imageFilename), mToastService(toastService)
+{
+}
+
+SaveResultDto RenameOperation::execute()
+{
+	const auto newFilename = getNewFilename();
+	if (newFilename.isEmpty()) {
+		return SaveResultDto(false, mPathToImageSource);
+	}
+
+	const bool renameOk = rename(newFilename);
+
+	if (renameOk) {
+		NotifyOperation operation(mToastService, tr("Image Renamed"),
+								  "Successfully renamed image to " + newFilename,
+								  NotificationTypes::Information);
+		operation.execute();
+		return SaveResultDto(true, mPathToImageSource);
+	} else {
+		NotifyOperation operation(mToastService, tr("Image Rename Failed"),
+								  "Failed to rename image to " + newFilename,
+								  NotificationTypes::Warning);
+		operation.execute();
+		return SaveResultDto(false, mPathToImageSource);
+	}
+}
+
+QString RenameOperation::getNewFilename() const
+{
+	bool ok;
+	QString newFilename = QInputDialog::getText(mParent, tr("Rename image"),
+												tr("New filename:"), QLineEdit::Normal,
+												mImageFilename, &ok);
+
+	return (ok ? newFilename : "");
+}
+
+bool RenameOperation::rename(const QString &newFilename)
+{
+	QFile file(mPathToImageSource);
+	const bool renameOk = file.rename(newFilename);
+	if (renameOk) {
+		mPathToImageSource = QFileInfo(file).absoluteFilePath();
+	}
+	return renameOk;
+}

--- a/src/gui/operations/RenameOperation.cpp
+++ b/src/gui/operations/RenameOperation.cpp
@@ -30,7 +30,7 @@ RenameOperation::RenameOperation(QWidget *parent, const QString &pathToImageSour
 RenameResultDto RenameOperation::execute()
 {
 	const auto newFilename = getNewFilename();
-	if (newFilename.isEmpty()) {
+	if (newFilename.isNull() || newFilename.isEmpty()) {
 		return RenameResultDto(false, mPathToImageSource);
 	}
 
@@ -38,35 +38,34 @@ RenameResultDto RenameOperation::execute()
 
 	if (renameOk) {
 		NotifyOperation operation(mToastService, tr("Image Renamed"),
-								  "Successfully renamed image to " + newFilename,
+								  tr("Successfully renamed image to ") + newFilename,
 								  NotificationTypes::Information);
 		operation.execute();
-		return RenameResultDto(true, mPathToImageSource);
 	} else {
 		NotifyOperation operation(mToastService, tr("Image Rename Failed"),
-								  "Failed to rename image to " + newFilename,
+								  tr("Failed to rename image to ") + newFilename,
 								  NotificationTypes::Warning);
 		operation.execute();
-		return RenameResultDto(false, mPathToImageSource);
 	}
+
+	return RenameResultDto(true, mPathToImageSource);
 }
 
 QString RenameOperation::getNewFilename() const
 {
-	bool ok;
 	QString newFilename = QInputDialog::getText(mParent, tr("Rename image"),
 												tr("New filename:"), QLineEdit::Normal,
-												mImageFilename, &ok);
+												mImageFilename);
 
-	return (ok ? newFilename : "");
+	return newFilename;
 }
 
 bool RenameOperation::rename(const QString &newFilename)
 {
 	QFile file(mPathToImageSource);
-	const bool renameOk = file.rename(newFilename);
-	if (renameOk) {
+	auto renameSuccessful = file.rename(newFilename);
+	if (renameSuccessful) {
 		mPathToImageSource = QFileInfo(file).absoluteFilePath();
 	}
-	return renameOk;
+	return renameSuccessful;
 }

--- a/src/gui/operations/RenameOperation.cpp
+++ b/src/gui/operations/RenameOperation.cpp
@@ -53,11 +53,19 @@ RenameResultDto RenameOperation::execute()
 
 QString RenameOperation::getNewFilename() const
 {
-	QString newFilename = QInputDialog::getText(mParent, tr("Rename image"),
-												tr("New filename:"), QLineEdit::Normal,
-												mImageFilename);
+	QInputDialog dialog;
 
-	return newFilename;
+	dialog.setInputMode(QInputDialog::TextInput);
+	dialog.setWindowTitle(tr("Rename image"));
+	dialog.setLabelText(tr("New filename:"));
+	dialog.setTextEchoMode(QLineEdit::Normal);
+	dialog.setTextValue(mImageFilename);
+	dialog.resize(270, 0);
+
+	if (QDialog::Accepted == dialog.exec()) {
+		return dialog.textValue();
+	}
+	return QString();
 }
 
 bool RenameOperation::rename(const QString &newFilename)

--- a/src/gui/operations/RenameOperation.cpp
+++ b/src/gui/operations/RenameOperation.cpp
@@ -20,18 +20,18 @@
 #include "RenameOperation.h"
 
 RenameOperation::RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService) :
-    mParent(parent),
-    mPathToImageSource(pathToImageSource),
-    mImageFilename(imageFilename),
-    mToastService(toastService)
+	mParent(parent),
+	mPathToImageSource(pathToImageSource),
+	mImageFilename(imageFilename),
+	mToastService(toastService)
 {
 }
 
-SaveResultDto RenameOperation::execute()
+RenameResultDto RenameOperation::execute()
 {
 	const auto newFilename = getNewFilename();
 	if (newFilename.isEmpty()) {
-		return SaveResultDto(false, mPathToImageSource);
+		return RenameResultDto(false, mPathToImageSource);
 	}
 
 	const bool renameOk = rename(newFilename);
@@ -41,13 +41,13 @@ SaveResultDto RenameOperation::execute()
 								  "Successfully renamed image to " + newFilename,
 								  NotificationTypes::Information);
 		operation.execute();
-		return SaveResultDto(true, mPathToImageSource);
+		return RenameResultDto(true, mPathToImageSource);
 	} else {
 		NotifyOperation operation(mToastService, tr("Image Rename Failed"),
 								  "Failed to rename image to " + newFilename,
 								  NotificationTypes::Warning);
 		operation.execute();
-		return SaveResultDto(false, mPathToImageSource);
+		return RenameResultDto(false, mPathToImageSource);
 	}
 }
 

--- a/src/gui/operations/RenameOperation.cpp
+++ b/src/gui/operations/RenameOperation.cpp
@@ -19,10 +19,11 @@
 
 #include "RenameOperation.h"
 
-#include <utility>
-
-RenameOperation::RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService)
-	: mParent(parent), mPathToImageSource(pathToImageSource), mImageFilename(imageFilename), mToastService(toastService)
+RenameOperation::RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService) :
+    mParent(parent),
+    mPathToImageSource(pathToImageSource),
+    mImageFilename(imageFilename),
+    mToastService(toastService)
 {
 }
 

--- a/src/gui/operations/RenameOperation.h
+++ b/src/gui/operations/RenameOperation.h
@@ -25,6 +25,8 @@
 #include <QFileInfo>
 #include <QInputDialog>
 
+#include <utility>
+
 #include "NotifyOperation.h"
 #include "src/common/dtos/SaveResultDto.h"
 #include "src/gui/IToastService.h"

--- a/src/gui/operations/RenameOperation.h
+++ b/src/gui/operations/RenameOperation.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Damir Porobic <damir.porobic@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KSNIP_RENAMEOPERATION_H
+#define KSNIP_RENAMEOPERATION_H
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QFileInfo>
+#include <QInputDialog>
+
+#include "NotifyOperation.h"
+#include "src/common/dtos/SaveResultDto.h"
+#include "src/gui/IToastService.h"
+
+class RenameOperation : public QObject
+{
+		Q_OBJECT
+public:
+	RenameOperation(QWidget *parent, const QString &pathToImageSource, const QString &imageFilename, IToastService *toastService);
+	~RenameOperation() override = default;
+	SaveResultDto execute();
+
+private:
+	QString getNewFilename() const;
+	bool rename(const QString &newFilename);
+
+	QWidget* mParent;
+	QString mPathToImageSource;
+	QString mImageFilename;
+	IToastService *mToastService;
+};
+
+#endif //KSNIP_RENAMEOPERATION_H

--- a/tests/mocks/CaptureTabStateHandlerMock.cpp
+++ b/tests/mocks/CaptureTabStateHandlerMock.cpp
@@ -55,6 +55,11 @@ void CaptureTabStateHandlerMock::setSaveState(int index, const SaveResultDto &sa
 
 }
 
+void CaptureTabStateHandlerMock::setRenameState(int index, const RenameResultDto &renameResult)
+{
+
+}
+
 int CaptureTabStateHandlerMock::count() const
 {
 	return 0;

--- a/tests/mocks/CaptureTabStateHandlerMock.h
+++ b/tests/mocks/CaptureTabStateHandlerMock.h
@@ -37,6 +37,7 @@ public:
 	QString path(int index) override;
 	QString filename(int index) override;
 	void setSaveState(int index, const SaveResultDto &saveResult) override;
+	void setRenameState(int index, const RenameResultDto &renameResult) override;
 	int count() const override;
 	int currentTabIndex() const override;
 


### PR DESCRIPTION
Feature #438 
Video demo: https://youtu.be/KvHMB7gMxrM (note that rename notification is displayed, but on the other screen)

Please note:
* I have used **tabs and spaces inconsistently** (because it wasn't clear to me which one is preferred)
* **No keyboard shortcut** was assigned to the rename action (what keyboard shortcut should be used, if any ?)
* **No icon** was assigned to the rename action (what icon should be used, if any ?)
