### PR TITLE
Use proper target for linking against kimageannotator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,8 +184,7 @@ target_link_libraries(ksnip
 					  Qt5::Xml
 					  Qt5::PrintSupport
 					  Qt5::DBus
-					  kImageAnnotator
-					  kColorPicker
+					  kImageAnnotator::kImageAnnotator
 					  Qt5::Svg
 					  )
 


### PR DESCRIPTION
kImageAnnotator in target_link_libraries searches for a library named
kImageAnnotator in the library search path.
kImageAnnotator::kImageAnnotator on the other hand is a special target
provided by cmake that achieves the same thing but does various nice
things in addition, like finding stuff in non-default places, setting up
include dirs and transitive dependencies (like kcolorpicker)