### PR TITLE
Disable building snap on unsupported architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,9 @@ apps:
       - network-observe
       - opengl
 
+architectures:
+  - build-on: amd64
+
 parts:
   ksnip:
     source: .


### PR DESCRIPTION
Since the content snap is only available on the amd64 architecture, this change makes it so the build server will not try (and fail) the build on other architectures.