### PR TITLE
Fix GitHub CI build on deb packages

### DIFF
--- a/.github/scripts/linux/deb/build_deb.sh
+++ b/.github/scripts/linux/deb/build_deb.sh
@@ -2,7 +2,6 @@
 
 cd ksnip-${VERSION_NUMBER}
 
-debuild -us -uc --lintian-opts --profile debian --preserve-envvar VERSION_SUFFIX
+dpkg-buildpackage -us -uc -i -b
 
 mv ${WORKSPACE}/ksnip_*.deb ${WORKSPACE}/ksnip-${VERSION}.deb
-

--- a/.github/scripts/linux/deb/debian/rules
+++ b/.github/scripts/linux/deb/debian/rules
@@ -11,7 +11,7 @@
 # package maintainers to append CFLAGS
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
-#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+#export DEB_LDFLAGS_MAINT_APPEND =
 
 
 %:
@@ -21,7 +21,7 @@
 #dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION_SUFIX=$(VERSION_SUFFIX) -DBUILD_NUMBER=$(BUILD_NUMBER) -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$(Qt5_DIR);$(INSTAL_PREFIX)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE);
+	dh_auto_configure -- -DVERSION_SUFIX=$(VERSION_SUFFIX) -DBUILD_NUMBER=$(BUILD_NUMBER) -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$(Qt5_DIR);$(INSTALL_PREFIX)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 
 override_dh_shlibdeps:
 	dh_shlibdeps -l"$(Qt5_DIR)/lib" --dpkg-shlibdeps-params=--ignore-missing-info

--- a/.github/scripts/linux/deb/debian/source/format
+++ b/.github/scripts/linux/deb/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/.github/scripts/linux/deb/setup_changelog_file.sh
+++ b/.github/scripts/linux/deb/setup_changelog_file.sh
@@ -4,7 +4,7 @@ cp CHANGELOG.md changelog
 sed -i '1,2d' changelog  #Remove header and empty line ad the beginning
 sed -i 's/\[\(.*[^]]*\)\].*/\1)/g' changelog # Replace links to issues with only number
 sed -i "s/^[[:blank:]]*$/\n -- Damir Porobic <damir.porobic@gmx.com>  ${BUILD_TIME}\n/" changelog # After every release add time and author
-sed -i 's/## Release \([0-9]*\.[0-9]*\.[0-9]*\)/ksnip (\1)  jessie; urgency=medium\n/' changelog # Rename release headers
+sed -i 's/## Release \([0-9]*\.[0-9]*\.[0-9]*\)/ksnip (\1) stable; urgency=medium\n/' changelog # Rename release headers
 sed -i 's/^\(\* .*\)/  \1/' changelog # Add two spaces before every entry
 printf "\n -- Damir Porobic <damir.porobic@gmx.com>  ${BUILD_TIME}\n" >> changelog # Add time and author for the first release
 cp changelog ksnip-${VERSION_NUMBER}/debian/


### PR DESCRIPTION
Essential fixes:

* Use `dpkg-buildpackage` instead of `debuild` to preserve envvars
* Fix typo in debian/rules

Optional fixes:

* debian/source/format: Use "3.0 (native)"
* debian/changelog: Use `stable` as suite name