### PR TITLE
ci: deb: Also install kimageannotator translation

### DIFF
--- a/.github/scripts/linux/deb/debian/control
+++ b/.github/scripts/linux/deb/debian/control
@@ -9,5 +9,6 @@ Homepage: http://ksnip.org
 Package: ksnip
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: libkimageannotator-common
 Description: Screenshot Tool
  Screenshot tool that provides many annotation features for your screenshots.

--- a/.github/scripts/linux/deb/debian/rules
+++ b/.github/scripts/linux/deb/debian/rules
@@ -25,3 +25,9 @@ override_dh_auto_configure:
 
 override_dh_shlibdeps:
 	dh_shlibdeps -l"$(Qt5_DIR)/lib" --dpkg-shlibdeps-params=--ignore-missing-info
+
+# Manually install kimageannotator translation files
+override_dh_auto_install:
+	dh_auto_install
+	mkdir -p $(CURDIR)/debian/ksnip/usr/
+	cp -r $(INSTALL_PREFIX)/share $(CURDIR)/debian/ksnip/usr/


### PR DESCRIPTION
This Pull Request closes: #359 .

NOTE: This Pull Request comes with inevitable side effects! Merge with caution.

CI-built ksnip package now additionally conflicts with libkimageannotator-common.

CI-built deb package provides kimageannotator translation files, which are supposed to be provided by libkimageannotator-common in Debian official packages. The additional conflicts relationship prevents file conflicts from happening.

This means users will not longer able to install CI-built ksnip deb package and distribution-provided KDE spectacle (KDE's default screenshot tool) together, because kde-spectacle depends on distribution-provided libkimageannotator libraries and translations.