### PR TITLE
Resize to content when normalizing window from fullscreen, after closing last tab

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -62,6 +62,7 @@ MainWindow::MainWindow(DependencyInjector *dependencyInjector) :
 	mDragAndDropProcessor(new DragAndDropProcessor(this)),
 	mUploadHandler(mDependencyInjector->get<IUploadHandler>()),
 	mSessionManagerRequestedQuit(false),
+	mResizeOnNormalize(false),
 	mCaptureHandler(CaptureHandlerFactory::create(mImageAnnotator, mNotificationService, mDependencyInjector, this)),
 	mPinWindowHandler(mDependencyInjector->get<IPinWindowHandler>()),
 	mVisibilityHandler(WidgetVisibilityHandlerFactory::create(this, mDependencyInjector->get<IPlatformChecker>())),
@@ -284,7 +285,10 @@ void MainWindow::closeEvent(QCloseEvent* event)
 void MainWindow::changeEvent(QEvent *event)
 {
 	if (event->type() == QEvent::WindowStateChange) {
-		if(isMinimized() && mTrayIcon->isVisible() && mConfig->minimizeToTray()) {
+		if(mResizeOnNormalize && !isMaximized()) {
+			mResizeOnNormalize = false;
+			resizeToContent();
+		} else if(isMinimized() && mTrayIcon->isVisible() && mConfig->minimizeToTray()) {
 			event->ignore();
 			mVisibilityHandler->hide();
 		}
@@ -759,6 +763,10 @@ void MainWindow::captureEmpty()
 {
 	setEnablements(false);
 	mWindowResizer->resetAndResize();
+
+	if (isWindowMaximized()) {
+		mResizeOnNormalize = true;
+	}
 }
 
 void MainWindow::showPinWindow()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -98,6 +98,7 @@ private:
 	TrayIcon *mTrayIcon;
 	QSharedPointer<INotificationService> mNotificationService;
 	bool mSessionManagerRequestedQuit;
+	bool mResizeOnNormalize;
 	QAction *mSaveAsAction;
 	QAction *mUploadAction;
 	QAction *mCopyAsDataUriAction;


### PR DESCRIPTION
Fixes #757 
Tested on Linux (KDE).