### PR TITLE
Implement settings search functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,7 @@ set(KSNIP_SRCS
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/StickerSettings.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/SnippingAreaSettings.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/SettingsDialog.cpp
+        ${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/SettingsFilter.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/TrayIconSettings.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/WatermarkSettings.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/settingsDialog/actions/ActionsSettings.cpp

--- a/src/gui/settingsDialog/ISettingsFilter.h
+++ b/src/gui/settingsDialog/ISettingsFilter.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Damir Porobic <damir.porobic@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KSNIP_ISETTINGSFILTER_H
+#define KSNIP_ISETTINGSFILTER_H
+
+#include <QList>
+#include <QStackedLayout>
+#include <QString>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+
+class ISettingsFilter
+{
+public:
+	explicit ISettingsFilter() = default;
+	~ISettingsFilter() = default;
+
+	virtual void filterSettings(const QString &filterString,
+                                QTreeWidget *treeWidget,
+                                QStackedLayout *stackedLayout,
+								QList<QTreeWidgetItem*> &navigatorItems) const = 0;
+};
+
+#endif //KSNIP_ISETTINGSFILTER_H

--- a/src/gui/settingsDialog/ISettingsFilter.h
+++ b/src/gui/settingsDialog/ISettingsFilter.h
@@ -33,9 +33,8 @@ public:
 	~ISettingsFilter() = default;
 
 	virtual void filterSettings(const QString &filterString,
-                                QTreeWidget *treeWidget,
-                                QStackedLayout *stackedLayout,
-								QList<QTreeWidgetItem*> &navigatorItems) const = 0;
+								QTreeWidget *treeWidget,
+								std::function<QWidget *(QTreeWidgetItem *)> getSettingsPageFun) const = 0;
 };
 
 #endif //KSNIP_ISETTINGSFILTER_H

--- a/src/gui/settingsDialog/SettingsDialog.cpp
+++ b/src/gui/settingsDialog/SettingsDialog.cpp
@@ -200,15 +200,20 @@ void SettingsDialog::initGui()
 
 void SettingsDialog::switchTab()
 {
-	mStackedLayout->setCurrentIndex(mNavigatorItems.indexOf(mTreeWidget->currentItem()));
+	if (mTreeWidget->selectedItems().size() == 0) {
+		mStackedLayout->setCurrentIndex(mNavigatorItems.size());
+	} else {
+		mStackedLayout->setCurrentIndex(mNavigatorItems.indexOf(mTreeWidget->currentItem()));
+	}
 }
 
 void SettingsDialog::filterSettings(const QString &filterString)
 {
 	mSettingsFilter->filterSettings(filterString,
 									mTreeWidget,
-									mStackedLayout,
-									mNavigatorItems);
+									[this](QTreeWidgetItem *treeWidgetItem) {
+		return mStackedLayout->itemAt(mNavigatorItems.indexOf(treeWidgetItem))->widget();
+	});
 }
 
 void SettingsDialog::okClicked()

--- a/src/gui/settingsDialog/SettingsDialog.cpp
+++ b/src/gui/settingsDialog/SettingsDialog.cpp
@@ -50,51 +50,53 @@ SettingsDialog::SettingsDialog(
 	mWatermarkSettings(new WatermarkSettings(mConfig, mScaledSizeProvider)),
 	mActionsSettings(new ActionsSettings(captureModes, platformChecker, mConfig)),
 	mPluginsSettings(new PluginsSettings(mConfig, fileDialogService, pluginFinder)),
+	mSearchSettingsLineEdit(new QLineEdit(this)),
 	mFtpUploaderSettings(new FtpUploaderSettings(mConfig))
 {
-    setWindowTitle(QApplication::applicationName() + QLatin1String(" - ") + tr("Settings"));
+	setWindowTitle(QApplication::applicationName() + QLatin1String(" - ") + tr("Settings"));
 
-    initGui();
+	initGui();
 
-    connect(mTreeWidget, &QTreeWidget::itemSelectionChanged, this, &SettingsDialog::switchTab);
+	connect(mTreeWidget, &QTreeWidget::itemSelectionChanged, this, &SettingsDialog::switchTab);
+	connect(mSearchSettingsLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::filterSettings);
 }
 
 SettingsDialog::~SettingsDialog()
 {
-    delete mOkButton;
-    delete mCancelButton;
-    delete mTreeWidget;
-    delete mStackedLayout;
-    delete mApplicationSettings;
-    delete mImageGrabberSettings;
-    delete mImgurUploaderSettings;
-    delete mAnnotationSettings;
-    delete mHotKeySettings;
-    delete mUploaderSettings;
-    delete mSaverSettings;
-    delete mStickerSettings;
-    delete mTrayIconSettings;
-    delete mSnippingAreaSettings;
-    delete mWatermarkSettings;
-    delete mActionsSettings;
-    delete mFtpUploaderSettings;
-    delete mPluginsSettings;
+	delete mOkButton;
+	delete mCancelButton;
+	delete mTreeWidget;
+	delete mStackedLayout;
+	delete mApplicationSettings;
+	delete mImageGrabberSettings;
+	delete mImgurUploaderSettings;
+	delete mAnnotationSettings;
+	delete mHotKeySettings;
+	delete mUploaderSettings;
+	delete mSaverSettings;
+	delete mStickerSettings;
+	delete mTrayIconSettings;
+	delete mSnippingAreaSettings;
+	delete mWatermarkSettings;
+	delete mActionsSettings;
+	delete mFtpUploaderSettings;
+	delete mPluginsSettings;
 }
 
 void SettingsDialog::saveSettings()
 {
-    mApplicationSettings->saveSettings();
-    mImageGrabberSettings->saveSettings();
-    mUploaderSettings->saveSettings();
-    mImgurUploaderSettings->saveSettings();
-    mScriptUploaderSettings->saveSettings();
-    mAnnotationSettings->saveSettings();
-    mHotKeySettings->saveSettings();
-    mSaverSettings->saveSettings();
-    mStickerSettings->saveSettings();
-    mTrayIconSettings->saveSettings();
-    mSnippingAreaSettings->saveSettings();
-    mWatermarkSettings->saveSettings();
+	mApplicationSettings->saveSettings();
+	mImageGrabberSettings->saveSettings();
+	mUploaderSettings->saveSettings();
+	mImgurUploaderSettings->saveSettings();
+	mScriptUploaderSettings->saveSettings();
+	mAnnotationSettings->saveSettings();
+	mHotKeySettings->saveSettings();
+	mSaverSettings->saveSettings();
+	mStickerSettings->saveSettings();
+	mTrayIconSettings->saveSettings();
+	mSnippingAreaSettings->saveSettings();
+	mWatermarkSettings->saveSettings();
 	mActionsSettings->saveSettings();
 	mFtpUploaderSettings->saveSettings();
 	mPluginsSettings->saveSettings();
@@ -102,26 +104,26 @@ void SettingsDialog::saveSettings()
 
 void SettingsDialog::initGui()
 {
-    mOkButton->setText(tr("OK"));
-    connect(mOkButton, &QPushButton::clicked, this, &SettingsDialog::okClicked);
+	mOkButton->setText(tr("OK"));
+	connect(mOkButton, &QPushButton::clicked, this, &SettingsDialog::okClicked);
 
-    mCancelButton->setText(tr("Cancel"));
-    connect(mCancelButton, &QPushButton::clicked, this, &SettingsDialog::cancelClicked);
+	mCancelButton->setText(tr("Cancel"));
+	connect(mCancelButton, &QPushButton::clicked, this, &SettingsDialog::cancelClicked);
 
-    auto buttonLayout = new QHBoxLayout;
-    buttonLayout->addWidget(mOkButton);
-    buttonLayout->addWidget(mCancelButton);
-    buttonLayout->setAlignment(Qt::AlignRight);
+	auto buttonLayout = new QHBoxLayout;
+	buttonLayout->addWidget(mOkButton);
+	buttonLayout->addWidget(mCancelButton);
+	buttonLayout->setAlignment(Qt::AlignRight);
 
-    mStackedLayout->addWidget(mApplicationSettings);
-    mStackedLayout->addWidget(mSaverSettings);
-    mStackedLayout->addWidget(mTrayIconSettings);
-    mStackedLayout->addWidget(mImageGrabberSettings);
-    mStackedLayout->addWidget(mSnippingAreaSettings);
-    mStackedLayout->addWidget(mUploaderSettings);
-    mStackedLayout->addWidget(mImgurUploaderSettings);
-    mStackedLayout->addWidget(mFtpUploaderSettings);
-    mStackedLayout->addWidget(mScriptUploaderSettings);
+	mStackedLayout->addWidget(mApplicationSettings);
+	mStackedLayout->addWidget(mSaverSettings);
+	mStackedLayout->addWidget(mTrayIconSettings);
+	mStackedLayout->addWidget(mImageGrabberSettings);
+	mStackedLayout->addWidget(mSnippingAreaSettings);
+	mStackedLayout->addWidget(mUploaderSettings);
+	mStackedLayout->addWidget(mImgurUploaderSettings);
+	mStackedLayout->addWidget(mFtpUploaderSettings);
+	mStackedLayout->addWidget(mScriptUploaderSettings);
 	mStackedLayout->addWidget(mAnnotationSettings);
 	mStackedLayout->addWidget(mStickerSettings);
 	mStackedLayout->addWidget(mWatermarkSettings);
@@ -165,37 +167,121 @@ void SettingsDialog::initGui()
 	mTreeWidget->addTopLevelItem(imageGrabber);
 	mTreeWidget->addTopLevelItem(uploader);
 	mTreeWidget->addTopLevelItem(annotator);
-    mTreeWidget->addTopLevelItem(hotkeys);
-    mTreeWidget->addTopLevelItem(actions);
-    mTreeWidget->addTopLevelItem(plugins);
+	mTreeWidget->addTopLevelItem(hotkeys);
+	mTreeWidget->addTopLevelItem(actions);
+	mTreeWidget->addTopLevelItem(plugins);
 	mTreeWidget->setHeaderHidden(true);
-    mTreeWidget->setItemSelected(mNavigatorItems[0], true);
-    mTreeWidget->setFixedWidth(mTreeWidget->minimumSizeHint().width() + mScaledSizeProvider->scaledWidth(100));
-    mTreeWidget->expandAll();
+	mTreeWidget->setItemSelected(mNavigatorItems[0], true);
+	mTreeWidget->setFixedWidth(mTreeWidget->minimumSizeHint().width() + mScaledSizeProvider->scaledWidth(100));
+	mTreeWidget->expandAll();
 
-    auto listAndStackLayout = new QHBoxLayout;
-    listAndStackLayout->addWidget(mTreeWidget);
-    listAndStackLayout->addLayout(mStackedLayout);
+	mSearchSettingsLineEdit->setPlaceholderText(tr("Search Settings..."));
+	mSearchSettingsLineEdit->setFixedWidth(mTreeWidget->width());
 
-    auto mainLayout = new QVBoxLayout();
-    mainLayout->addLayout(listAndStackLayout);
-    mainLayout->addLayout(buttonLayout);
+	auto settingsNavigationLayout = new QVBoxLayout();
+	settingsNavigationLayout->addWidget(mSearchSettingsLineEdit);
+	settingsNavigationLayout->addWidget(mTreeWidget);
 
-    setLayout(mainLayout);
+	auto listAndStackLayout = new QHBoxLayout;
+	listAndStackLayout->addLayout(settingsNavigationLayout);
+	listAndStackLayout->addLayout(mStackedLayout);
+
+	auto mainLayout = new QVBoxLayout();
+	mainLayout->addLayout(listAndStackLayout);
+	mainLayout->addLayout(buttonLayout);
+
+	setLayout(mainLayout);
 }
 
 void SettingsDialog::switchTab()
 {
-    mStackedLayout->setCurrentIndex(mNavigatorItems.indexOf(mTreeWidget->currentItem()));
+	mStackedLayout->setCurrentIndex(mNavigatorItems.indexOf(mTreeWidget->currentItem()));
+}
+
+void SettingsDialog::filterSettings(const QString &filterString)
+{
+	if (filterString.isEmpty()) {
+		foreach (auto navigatorItem, mNavigatorItems) {
+			navigatorItem->setHidden(false);
+		}
+		return;
+	}
+
+	for (int index = 0; index < mTreeWidget->topLevelItemCount(); ++index) {
+		filterNavigatorItem(mTreeWidget->topLevelItem(index), filterString);
+	}
+
+	for (int index = 0; index < mNavigatorItems.size(); ++index) {
+		if (!mNavigatorItems[index]->isHidden()) {
+			mTreeWidget->setCurrentItem(mNavigatorItems[index]);
+			return;
+		}
+	}
+}
+
+bool SettingsDialog::filterNavigatorItem(QTreeWidgetItem *navigatorItem, const QString &filterString)
+{
+	bool filtered{true};
+
+	if (navigatorItem->text(0).contains(filterString, Qt::CaseInsensitive)) {
+		navigatorItem->setDisabled(false);
+		for (int index = 0; index < navigatorItem->childCount(); ++index) {
+			filterNavigatorItem(navigatorItem->child(index), filterString);
+		}
+		filtered = false;
+	} else {
+		filtered = !settingsPageContainsFilterString(mStackedLayout->itemAt(mNavigatorItems.indexOf(navigatorItem))->widget(), filterString);
+
+		for (int index = 0; index < navigatorItem->childCount(); ++index) {
+			filtered &= filterNavigatorItem(navigatorItem->child(index), filterString);
+		}
+	}
+
+	navigatorItem->setHidden(filtered);
+	return filtered;
+}
+
+bool SettingsDialog::settingsPageContainsFilterString(QWidget *settingsPage, const QString &filterString)
+{
+	foreach (auto button, settingsPage->findChildren<QAbstractButton*>()) {
+		if (button->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto label, settingsPage->findChildren<QLabel*>()) {
+		if (label->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto lineEdit, settingsPage->findChildren<QLineEdit*>()) {
+		if (lineEdit->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+		if (lineEdit->placeholderText().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto comboBox, settingsPage->findChildren<QComboBox*>()) {
+		for (int index = 0; index < comboBox->count(); ++index) {
+			if (comboBox->itemText(index).contains(filterString, Qt::CaseInsensitive)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 void SettingsDialog::okClicked()
 {
-    saveSettings();
-    close();
+	saveSettings();
+	close();
 }
 
 void SettingsDialog::cancelClicked()
 {
-    close();
+	close();
 }

--- a/src/gui/settingsDialog/SettingsDialog.cpp
+++ b/src/gui/settingsDialog/SettingsDialog.cpp
@@ -36,6 +36,7 @@ SettingsDialog::SettingsDialog(
 	mStackedLayout(new QStackedLayout),
 	mConfig(config),
 	mScaledSizeProvider(scaledSizeProvider),
+	mSettingsFilter(new SettingsFilter()),
 	mEmptyWidget(new QWidget()),
 	mApplicationSettings(new ApplicationSettings(mConfig)),
 	mImageGrabberSettings(new ImageGrabberSettings(mConfig)),
@@ -204,82 +205,10 @@ void SettingsDialog::switchTab()
 
 void SettingsDialog::filterSettings(const QString &filterString)
 {
-	if (filterString.isEmpty()) {
-		foreach (auto navigatorItem, mNavigatorItems) {
-			navigatorItem->setHidden(false);
-		}
-		return;
-	}
-
-	for (int index = 0; index < mTreeWidget->topLevelItemCount(); ++index) {
-		filterNavigatorItem(mTreeWidget->topLevelItem(index), filterString);
-	}
-
-	for (int index = 0; index < mNavigatorItems.size(); ++index) {
-		if (!mNavigatorItems[index]->isHidden()) {
-			mTreeWidget->setCurrentItem(mNavigatorItems[index]);
-			return;
-		}
-	}
-
-	mTreeWidget->clearSelection();
-	mStackedLayout->setCurrentIndex(mNavigatorItems.size());
-}
-
-bool SettingsDialog::filterNavigatorItem(QTreeWidgetItem *navigatorItem, const QString &filterString)
-{
-	bool isFiltered{true};
-
-	if (navigatorItem->text(0).contains(filterString, Qt::CaseInsensitive)) {
-		navigatorItem->setDisabled(false);
-		for (int index = 0; index < navigatorItem->childCount(); ++index) {
-			filterNavigatorItem(navigatorItem->child(index), filterString);
-		}
-		isFiltered = false;
-	} else {
-		isFiltered = !settingsPageContainsFilterString(mStackedLayout->itemAt(mNavigatorItems.indexOf(navigatorItem))->widget(), filterString);
-
-		for (int index = 0; index < navigatorItem->childCount(); ++index) {
-			isFiltered &= filterNavigatorItem(navigatorItem->child(index), filterString);
-		}
-	}
-
-	navigatorItem->setHidden(isFiltered);
-	return isFiltered;
-}
-
-bool SettingsDialog::settingsPageContainsFilterString(QWidget *settingsPage, const QString &filterString)
-{
-	foreach (auto button, settingsPage->findChildren<QAbstractButton*>()) {
-		if (button->text().contains(filterString, Qt::CaseInsensitive)) {
-			return true;
-		}
-	}
-
-	foreach (auto label, settingsPage->findChildren<QLabel*>()) {
-		if (label->text().contains(filterString, Qt::CaseInsensitive)) {
-			return true;
-		}
-	}
-
-	foreach (auto lineEdit, settingsPage->findChildren<QLineEdit*>()) {
-		if (lineEdit->text().contains(filterString, Qt::CaseInsensitive)) {
-			return true;
-		}
-		if (lineEdit->placeholderText().contains(filterString, Qt::CaseInsensitive)) {
-			return true;
-		}
-	}
-
-	foreach (auto comboBox, settingsPage->findChildren<QComboBox*>()) {
-		for (int index = 0; index < comboBox->count(); ++index) {
-			if (comboBox->itemText(index).contains(filterString, Qt::CaseInsensitive)) {
-				return true;
-			}
-		}
-	}
-
-	return false;
+	mSettingsFilter->filterSettings(filterString,
+									mTreeWidget,
+									mStackedLayout,
+									mNavigatorItems);
 }
 
 void SettingsDialog::okClicked()

--- a/src/gui/settingsDialog/SettingsDialog.h
+++ b/src/gui/settingsDialog/SettingsDialog.h
@@ -46,9 +46,9 @@
 
 class SettingsDialog : public QDialog
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
-    explicit SettingsDialog(
+	explicit SettingsDialog(
 			const QList<CaptureModes> &captureModes,
 			const QSharedPointer<IConfig> &config,
 			const QSharedPointer<IScaledSizeProvider> &scaledSizeProvider,
@@ -57,39 +57,44 @@ public:
 			const QSharedPointer<IPlatformChecker> &platformChecker,
 			const QSharedPointer<IPluginFinder> &pluginFinder,
 			QWidget *parent);
-    ~SettingsDialog() override;
+	~SettingsDialog() override;
 
 private:
 	QSharedPointer<IConfig> mConfig;
 	QSharedPointer<IScaledSizeProvider> mScaledSizeProvider;
-    QPushButton *mOkButton;
-    QPushButton *mCancelButton;
+	QPushButton *mOkButton;
+	QPushButton *mCancelButton;
 	ApplicationSettings *mApplicationSettings;
 	ImageGrabberSettings *mImageGrabberSettings;
 	ImgurUploaderSettings *mImgurUploaderSettings;
 	ScriptUploaderSettings *mScriptUploaderSettings;
 	HotKeySettings *mHotKeySettings;
-    AnnotationSettings *mAnnotationSettings;
-    UploaderSettings *mUploaderSettings;
-    SaverSettings *mSaverSettings;
-    StickerSettings *mStickerSettings;
+	AnnotationSettings *mAnnotationSettings;
+	UploaderSettings *mUploaderSettings;
+	SaverSettings *mSaverSettings;
+	StickerSettings *mStickerSettings;
 	TrayIconSettings *mTrayIconSettings;
-    SnippingAreaSettings *mSnippingAreaSettings;
+	SnippingAreaSettings *mSnippingAreaSettings;
 	WatermarkSettings *mWatermarkSettings;
 	ActionsSettings *mActionsSettings;
 	FtpUploaderSettings *mFtpUploaderSettings;
 	PluginsSettings *mPluginsSettings;
+	QLineEdit *mSearchSettingsLineEdit;
 	QTreeWidget *mTreeWidget;
-    QStackedLayout *mStackedLayout;
-    QList<QTreeWidgetItem*> mNavigatorItems;
+	QStackedLayout *mStackedLayout;
+	QList<QTreeWidgetItem*> mNavigatorItems;
 
-    void saveSettings();
-    void initGui();
+	void saveSettings();
+	void initGui();
+
+	bool filterNavigatorItem(QTreeWidgetItem *navigatorItem, const QString &filterString);
+	bool settingsPageContainsFilterString(QWidget *settingsPage, const QString &filterString);
 
 private slots:
-    void switchTab();
-    void cancelClicked();
-    void okClicked();
+	void switchTab();
+	void filterSettings(const QString &filterString);
+	void cancelClicked();
+	void okClicked();
 };
 
 #endif // KSNIP_SETTINGSDIALOG_H

--- a/src/gui/settingsDialog/SettingsDialog.h
+++ b/src/gui/settingsDialog/SettingsDialog.h
@@ -29,6 +29,7 @@
 #include "AnnotationSettings.h"
 #include "ApplicationSettings.h"
 #include "ImageGrabberSettings.h"
+#include "SettingsFilter.h"
 #include "HotKeySettings.h"
 #include "SaverSettings.h"
 #include "StickerSettings.h"
@@ -62,6 +63,7 @@ public:
 private:
 	QSharedPointer<IConfig> mConfig;
 	QSharedPointer<IScaledSizeProvider> mScaledSizeProvider;
+	QSharedPointer<ISettingsFilter> mSettingsFilter;
 	QPushButton *mOkButton;
 	QPushButton *mCancelButton;
 	QWidget *mEmptyWidget;
@@ -87,9 +89,6 @@ private:
 
 	void saveSettings();
 	void initGui();
-
-	bool filterNavigatorItem(QTreeWidgetItem *navigatorItem, const QString &filterString);
-	bool settingsPageContainsFilterString(QWidget *settingsPage, const QString &filterString);
 
 private slots:
 	void switchTab();

--- a/src/gui/settingsDialog/SettingsDialog.h
+++ b/src/gui/settingsDialog/SettingsDialog.h
@@ -64,6 +64,7 @@ private:
 	QSharedPointer<IScaledSizeProvider> mScaledSizeProvider;
 	QPushButton *mOkButton;
 	QPushButton *mCancelButton;
+	QWidget *mEmptyWidget;
 	ApplicationSettings *mApplicationSettings;
 	ImageGrabberSettings *mImageGrabberSettings;
 	ImgurUploaderSettings *mImgurUploaderSettings;

--- a/src/gui/settingsDialog/SettingsFilter.cpp
+++ b/src/gui/settingsDialog/SettingsFilter.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 Damir Porobic <damir.porobic@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <QAbstractButton>
+#include <QComboBox>
+#include <QLabel>
+#include <QLineEdit>
+
+#include "SettingsFilter.h"
+
+void SettingsFilter::filterSettings(const QString &filterString,
+									QTreeWidget *treeWidget,
+									QStackedLayout *stackedLayout,
+									QList<QTreeWidgetItem *> &navigatorItems) const
+{
+	if (filterString.isEmpty()) {
+		foreach (auto navigatorItem, navigatorItems) {
+			navigatorItem->setHidden(false);
+		}
+		return;
+	}
+
+	for (int index = 0; index < treeWidget->topLevelItemCount(); ++index) {
+		filterNavigatorItem(treeWidget->topLevelItem(index), navigatorItems, stackedLayout, filterString);
+	}
+
+	for (int index = 0; index < navigatorItems.size(); ++index) {
+		if (!navigatorItems[index]->isHidden()) {
+			treeWidget->setCurrentItem(navigatorItems[index]);
+			return;
+		}
+	}
+
+	treeWidget->clearSelection();
+	stackedLayout->setCurrentIndex(navigatorItems.size());
+}
+
+bool SettingsFilter::filterNavigatorItem(QTreeWidgetItem *navigatorItem,
+										 QList<QTreeWidgetItem *> &navigatorItems,
+										 QStackedLayout *stackedLayout,
+										 const QString &filterString) const
+{
+	bool isFiltered{true};
+
+	if (navigatorItem->text(0).contains(filterString, Qt::CaseInsensitive)) {
+		navigatorItem->setDisabled(false);
+		for (int index = 0; index < navigatorItem->childCount(); ++index) {
+			filterNavigatorItem(navigatorItem->child(index), navigatorItems, stackedLayout, filterString);
+		}
+		isFiltered = false;
+	} else {
+		isFiltered = !settingsPageContainsFilterString(stackedLayout->itemAt(navigatorItems.indexOf(navigatorItem))->widget(), filterString);
+
+		for (int index = 0; index < navigatorItem->childCount(); ++index) {
+			isFiltered &= filterNavigatorItem(navigatorItem->child(index), navigatorItems, stackedLayout, filterString);
+		}
+	}
+
+	navigatorItem->setHidden(isFiltered);
+	return isFiltered;
+}
+
+bool SettingsFilter::settingsPageContainsFilterString(QWidget *settingsPage, const QString &filterString) const
+{
+	foreach (auto button, settingsPage->findChildren<QAbstractButton*>()) {
+		if (button->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto label, settingsPage->findChildren<QLabel*>()) {
+		if (label->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto lineEdit, settingsPage->findChildren<QLineEdit*>()) {
+		if (lineEdit->text().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+		if (lineEdit->placeholderText().contains(filterString, Qt::CaseInsensitive)) {
+			return true;
+		}
+	}
+
+	foreach (auto comboBox, settingsPage->findChildren<QComboBox*>()) {
+		for (int index = 0; index < comboBox->count(); ++index) {
+			if (comboBox->itemText(index).contains(filterString, Qt::CaseInsensitive)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/src/gui/settingsDialog/SettingsFilter.h
+++ b/src/gui/settingsDialog/SettingsFilter.h
@@ -30,18 +30,15 @@ public:
 
 	void filterSettings(const QString &filterString,
 						QTreeWidget *treeWidget,
-						QStackedLayout *stackedLayout,
-						QList<QTreeWidgetItem*> &navigatorItems) const override;
+						std::function<QWidget *(QTreeWidgetItem *)> getSettingsPageFun) const override;
 
 private:
 	bool filterNavigatorItem(QTreeWidgetItem *navigatorItem,
-							 QList<QTreeWidgetItem *> &navigatorItems,
-							 QStackedLayout *stackedLayout,
-							 const QString &filterString) const;
+							 const QString &filterString,
+							 std::function<QWidget *(QTreeWidgetItem *)> getSettingsPageFun) const;
 
 	bool settingsPageContainsFilterString(QWidget *settingsPage,
 										  const QString &filterString) const;
-
 };
 
 #endif //KSNIP_SETTINGSFILTER_H

--- a/src/gui/settingsDialog/SettingsFilter.h
+++ b/src/gui/settingsDialog/SettingsFilter.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Damir Porobic <damir.porobic@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KSNIP_SETTINGSFILTER_H
+#define KSNIP_SETTINGSFILTER_H
+
+#include "ISettingsFilter.h"
+
+class SettingsFilter : public ISettingsFilter
+{
+public:
+	explicit SettingsFilter() = default;
+	~SettingsFilter() = default;
+
+	void filterSettings(const QString &filterString,
+						QTreeWidget *treeWidget,
+						QStackedLayout *stackedLayout,
+						QList<QTreeWidgetItem*> &navigatorItems) const override;
+
+private:
+	bool filterNavigatorItem(QTreeWidgetItem *navigatorItem,
+							 QList<QTreeWidgetItem *> &navigatorItems,
+							 QStackedLayout *stackedLayout,
+							 const QString &filterString) const;
+
+	bool settingsPageContainsFilterString(QWidget *settingsPage,
+										  const QString &filterString) const;
+
+};
+
+#endif //KSNIP_SETTINGSFILTER_H


### PR DESCRIPTION
Implements: https://github.com/ksnip/ksnip/issues/619

- searches for search term in navigation panel (left side of the dialog) as well as in the controls in each corresponding settings page
- if search term is found in the title of the navigator item, the navigator item and its parent will be toggled visible
- if search term is not found in the title of the navigator item or in any child of the navigator item or its settings page, the control will be toggled invisible
- on every filtering step (on every character written/removed in the search field), the settings page of the first navigator item that is not hidden is displayed