### PR TITLE
Restore snap description

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,6 +4,8 @@ adopt-info: ksnip
 icon: desktop/ksnip.svg
 grade: stable
 confinement: strict
+description: |
+  Qt based cross-platform screenshot tool that provides many annotation features for your screenshots.
 compression: lzo
 
 apps:


### PR DESCRIPTION
This should temporarily fix the upload issue.
The problem seems to be that when reading the description from the appdata file it finds some incorrect unicode characters
as per the answer on the forum: https://forum.snapcraft.io/t/ksnip-snap-package-not-uploaded-to-the-store/28225/2