### PR TITLE
Adds a setting (default false) to use custom tray icon image

### DIFF
--- a/src/backend/config/Config.cpp
+++ b/src/backend/config/Config.cpp
@@ -320,6 +320,33 @@ void Config::setUseTrayIcon(bool enabled)
 	saveValue(ConfigOptions::useTrayIconString(), enabled);
 }
 
+bool Config::useCustomTrayIconImage() const
+{
+	return loadValue(ConfigOptions::useCustomTrayIconImageString(), false).toBool();
+}
+
+void Config::setCustomTrayIconImage(bool enabled)
+{
+	if (useCustomTrayIconImage() == enabled) {
+		return;
+	}
+	saveValue(ConfigOptions::useCustomTrayIconImageString(), enabled);
+}
+
+QString Config::customTrayIconImageFile() const
+{
+	return loadValue(ConfigOptions::customTrayIconImageFileString(), "").toString();
+}
+
+void Config::setCustomTrayIconImageFile(const QString& filepath)
+{
+	if(customTrayIconImageFile() == filepath) {
+		return;
+	}
+
+	saveValue(ConfigOptions::customTrayIconImageFileString(), filepath);
+}
+
 bool Config::minimizeToTray() const
 {
 	return loadValue(ConfigOptions::minimizeToTrayString(), true).toBool();

--- a/src/backend/config/Config.h
+++ b/src/backend/config/Config.h
@@ -104,6 +104,11 @@ public:
 	bool useTrayIcon() const override;
 	void setUseTrayIcon(bool enabled) override;
 
+	bool useCustomTrayIconImage() const override;
+	void setCustomTrayIconImage(bool enabled) override;
+	QString customTrayIconImageFile() const override;
+	void setCustomTrayIconImageFile(const QString &filename) override;
+
 	bool minimizeToTray() const override;
 	void setMinimizeToTray(bool enabled) override;
 

--- a/src/backend/config/ConfigOptions.cpp
+++ b/src/backend/config/ConfigOptions.cpp
@@ -159,6 +159,16 @@ QString ConfigOptions::useTrayIconString()
 	return applicationSectionString() + QLatin1String("UseTrayIcon");
 }
 
+QString ConfigOptions::useCustomTrayIconImageString()
+{
+	return applicationSectionString() + QLatin1String("UseCustomTrayIconImage");
+}
+
+QString ConfigOptions::customTrayIconImageFileString()
+{
+	return applicationSectionString() + QLatin1String("CustomTrayIconImageFile");
+}
+
 QString ConfigOptions::minimizeToTrayString()
 {
 	return applicationSectionString() + QLatin1String("MinimizeToTray");

--- a/src/backend/config/ConfigOptions.h
+++ b/src/backend/config/ConfigOptions.h
@@ -53,6 +53,8 @@ public:
 	static QString trayIconDefaultActionModeString();
 	static QString trayIconDefaultCaptureModeString();
 	static QString useTrayIconString();
+	static QString useCustomTrayIconImageString();
+	static QString customTrayIconImageFileString();
 	static QString minimizeToTrayString();
 	static QString closeToTrayString();
 	static QString trayIconNotificationsEnabledString();

--- a/src/backend/config/IConfig.h
+++ b/src/backend/config/IConfig.h
@@ -99,6 +99,12 @@ public:
 	virtual bool useTrayIcon() const = 0;
 	virtual void setUseTrayIcon(bool enabled) = 0;
 
+	virtual bool useCustomTrayIconImage() const = 0;
+	virtual void setCustomTrayIconImage(bool enabled) = 0;
+
+	virtual QString customTrayIconImageFile() const = 0;
+	virtual void setCustomTrayIconImageFile(const QString &filename) = 0;
+
 	virtual bool minimizeToTray() const = 0;
 	virtual void setMinimizeToTray(bool enabled) = 0;
 

--- a/src/gui/settingsDialog/TrayIconSettings.h
+++ b/src/gui/settingsDialog/TrayIconSettings.h
@@ -26,6 +26,10 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QRadioButton>
+#include <QFileDialog>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QMessageBox>
 
 #include "src/backend/config/IConfig.h"
 #include "src/common/helper/EnumTranslator.h"
@@ -53,6 +57,15 @@ private:
 	QGroupBox *mDefaultActionGroupBox;
 	QSharedPointer<IConfig> mConfig;
 
+	// settings for customizing the tray icon image
+	QRadioButton *mTrayIconDefaultRadioButton;
+	QRadioButton *mTrayIconCustomRadioButton;
+	QLineEdit *mTrayIconLineEdit;
+	QPushButton *mTrayIconCustomFileSelectButton;
+	QGroupBox *mTrayIconGroupBox;
+	QGridLayout *mTrayIconLayout;
+
+
 	void initGui();
 	void loadConfig();
 	void populateDefaultActionCaptureModeCombobox(const QList<CaptureModes> &captureModes);
@@ -60,6 +73,7 @@ private:
 	int indexOfSelectedCaptureMode() const;
 
 private slots:
+	void selectCustomImage();
 	void useTrayIconChanged();
 };
 


### PR DESCRIPTION
This adds in a setting to use a custom tray icon. It works with svgs, and I've got it set on my system now to use the same icon for ksnip from my icon pack.

# New Settings

![image](https://user-images.githubusercontent.com/6182419/182064377-af70dbd4-3b5d-4e19-b150-ac5c0811c8f8.png)

(note: ksnip doesn't seem to be able to take screenshots of it's own settings window so I had to use Spectacle, not sure if that's intentional or not)

# Example custom icon

![image](https://user-images.githubusercontent.com/6182419/182064269-a52a62a3-6007-483c-92b6-5341a4314cf3.png)

This is the first time I touched C++ since college, so if I did anything wrong let me know!

TODO:
* [ ] Display error message to user on falling back to default icon, or at least log it somehow
* [ ] Run tests (if they're not done automatically by GitHub)