### PR TITLE
downgrading the required Qt5 version to be compatible with CentOS-7 provided version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,7 @@
 name: linux
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
     tags:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
-          version: '5.12.7'
+          version: '5.9.7'
           host: 'linux'
           install-deps: 'true'
 


### PR DESCRIPTION
one line diff for the rpm linux target only to keep the CentOS-7 users happy... 