### PR TITLE
fix: failed to capture fullscreen under kwin+wayland

### DIFF
--- a/desktop/org.ksnip.ksnip.desktop
+++ b/desktop/org.ksnip.ksnip.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=ksnip
+Exec=/usr/bin/ksnip
 Icon=ksnip
 Terminal=false
 StartupNotify=false


### PR DESCRIPTION
When trying to capture full-screen screenshots, ksnip fails and the following log can be found in journalctl:

```
kwin_wayland[531]: kwin_effect_screenshot: Process 116763 tried to take a screenshot without being granted to DBus interface "org.kde.kwin.Screenshot"
```

According to https://github.com/flameshot-org/flameshot/issues/1380#issuecomment-784996738 and https://github.com/abhijeetviswa/flameshot/commit/faae710d471c523421140b828b7a00c1ec0c8185, we need to use absolute path to get rid of this error.

The purposed workaround is also implemented in the official flameshot repo, though by a slightly complicated manner:

- https://github.com/flameshot-org/flameshot/blob/3ededae5745761d23907d65bbaebb283f6f8e3f2/CMakeLists.txt#L69
- https://github.com/flameshot-org/flameshot/blob/3ededae5745761d23907d65bbaebb283f6f8e3f2/src/CMakeLists.txt#L317-L318
- https://github.com/flameshot-org/flameshot/blob/3ededae5745761d23907d65bbaebb283f6f8e3f2/data/desktopEntry/package/org.flameshot.Flameshot.desktop#L40

On my machine, which is a multi-screen Arch Linux x86_64 using KDE + Wayland, the full-screen capturing function works with this patch applied.