### PR TITLE
[Ubuntu/Gnome] Add ksnip to the list of "open with" entries when right clicking an image file

### DIFF
--- a/desktop/org.ksnip.ksnip.desktop
+++ b/desktop/org.ksnip.ksnip.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=/usr/bin/ksnip
+Exec=/usr/bin/ksnip %F
 Icon=ksnip
 Terminal=false
 StartupNotify=false


### PR DESCRIPTION
Ksnip can open existing files. Having this option is a convenience.

My personal workflow:

1. make screenshot by hitting `prt-screen` and have the default screenshot application do its thing.
2. A notification appears allowing me to view the saved screenshot. Many times I am finished as I don't need to do anything more to the image.
3. Sometimes I want to edit it with Ksnip: In that case I can select ksnip from the "open with" menu item.