### PR TITLE
Install desktop file without execute permission

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Add metadata file
 
 if(UNIX AND NOT APPLE)
-	install(PROGRAMS org.ksnip.ksnip.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+	install(FILES org.ksnip.ksnip.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 	install(FILES ksnip.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)
 	install(FILES org.ksnip.ksnip.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 endif()


### PR DESCRIPTION
From CMake's `INSTALL()` [documentation](https://cmake.org/cmake/help/v3.30/command/install.html#programs):

> The `PROGRAMS` form is identical to the `FILES` form except that the default permissions for the installed file also include `OWNER_EXECUTE`, `GROUP_EXECUTE`, and `WORLD_EXECUTE`. This form is intended to install programs that are not targets, such as shell scripts.

This silences a message displayed by `systemd-xdg-autostart-generator` when you symlink KSnip's desktop file (`/usr/share/applications/org.ksnip.ksnip.desktop`) to `~/.config/autostart`:

>`systemd-xdg-autostart-generator`: Configuration file /home/gui/.config/autostart/org.ksnip.ksnip.desktop is marked executable. Please remove executable permission bits. Proceeding anyway.
