### PR TITLE
New: Allow pixel based adjustments via arrow keys when capturing an area.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Release 1.11.0
+* New: Allow pixel based adjustments via arrow keys when capturing an area. ([#646](https://github.com/ksnip/ksnip/issues/646), [#816](https://github.com/ksnip/ksnip/issues/816), [#887](https://github.com/ksnip/ksnip/issues/887), [#1002](https://github.com/ksnip/ksnip/issues/1002))
 * Fixed: Cannot compile from source, kImageAnnotatorConfig not found despite being built and installed. ([#1027](https://github.com/ksnip/ksnip/issues/1027))
 * New kImageAnnotator: Allow copying items between tabs. ([#318](https://github.com/ksnip/kImageAnnotator/issues/318))
 * New kImageAnnotator: CTRL + A does not select all text typed. ([#198](https://github.com/ksnip/kImageAnnotator/issues/198))

--- a/desktop/org.ksnip.ksnip.appdata.xml
+++ b/desktop/org.ksnip.ksnip.appdata.xml
@@ -88,6 +88,7 @@
         <release type="stable" version="1.11.0" date="2024-03-01T00:00:00Z">
             <description>
                 <ul>
+                    <li>New: Allow pixel based adjustments via arrow keys when capturing an area.</li>
                     <li>Fixed: Cannot compile from source, kImageAnnotatorConfig not found despite being built and installed.</li>
                     <li>New kImageAnnotator: Allow copying items between tabs.</li>
                     <li>New kImageAnnotator: CTRL + A does not select all text typed.</li>

--- a/src/gui/snippingArea/AbstractSnippingArea.cpp
+++ b/src/gui/snippingArea/AbstractSnippingArea.cpp
@@ -232,6 +232,7 @@ void AbstractSnippingArea::keyPressEvent(QKeyEvent *event)
 		mIsSwitchPressed = true;
 	}
 
+	mSelector->handleKeyPress(event);
     mResizer->handleKeyPress(event);
 	update();
 

--- a/src/gui/snippingArea/SnippingAreaSelector.cpp
+++ b/src/gui/snippingArea/SnippingAreaSelector.cpp
@@ -23,7 +23,8 @@ SnippingAreaSelector::SnippingAreaSelector(const QSharedPointer<IConfig> &config
 	QObject(parent),
 	mIsActive(false),
 	mConfig(config),
-	mIsMouseDown(false)
+	mIsMouseDown(false),
+	mMouseCursor()
 {
 
 }
@@ -95,6 +96,29 @@ void SnippingAreaSelector::handleMouseMove(const QPointF &pos)
 		}
 
 		updateAdorner(pos);
+	}
+}
+
+void SnippingAreaSelector::handleKeyPress(QKeyEvent *event)
+{
+	if (mIsActive) {
+		// Get the current mouse cursor position and move it.
+		// This triggers the mouse move event
+		const QPoint mouseCursorPosition = mMouseCursor.pos();
+		switch (event->key()) {
+		case Qt::Key_Up:
+			mMouseCursor.setPos(mouseCursorPosition + QPoint(0, -1));
+			break;
+		case Qt::Key_Down:
+			mMouseCursor.setPos(mouseCursorPosition + QPoint(0, 1));
+			break;
+		case Qt::Key_Left:
+			mMouseCursor.setPos(mouseCursorPosition + QPoint(-1, 0));
+			break;
+		case Qt::Key_Right:
+			mMouseCursor.setPos(mouseCursorPosition + QPoint(1, 0));
+			break;
+		}
 	}
 }
 

--- a/src/gui/snippingArea/SnippingAreaSelector.h
+++ b/src/gui/snippingArea/SnippingAreaSelector.h
@@ -21,6 +21,7 @@
 #define KSNIP_SNIPPINGAREASELECTOR_H
 
 #include <QPainter>
+#include <QKeyEvent>
 
 #include "SnippingAreaAdorner.h"
 #include "src/backend/config/Config.h"
@@ -39,6 +40,7 @@ public:
 	void handleMousePress(const QPointF &pos);
 	void handleMouseRelease();
 	void handleMouseMove(const QPointF &pos);
+	void handleKeyPress(QKeyEvent *event);
 	void setBackgroundImage(const QPixmap *background);
 
 signals:
@@ -55,6 +57,7 @@ private:
 	QRectF mSnippingAreaGeometry;
 	QColor mAdornerColor;
 	QColor mCursorColor;
+	QCursor mMouseCursor;
 
 	void setupAdorner();
 	void setIsMouseDown(bool isMouseDown);

--- a/src/gui/snippingArea/SnippingAreaSelectorInfoText.cpp
+++ b/src/gui/snippingArea/SnippingAreaSelectorInfoText.cpp
@@ -32,6 +32,7 @@ void SnippingAreaSelectorInfoText::updateInfoText()
 
 	QStringList infoTextLines = {
 			tr("Click and Drag to select a rectangular area or press ESC to quit."),
+			tr("Use the arrow keys to make fine adjustments."),
 			mIsResizingDefault ? dontResizeAfterSelection : resizeAfterSelection,
 			tr("Operation will be canceled after 60 sec when no selection made."),
 			tr("This message can be disabled via settings.")


### PR DESCRIPTION
This allows to adjust the cursor position with the arrow keys when capturing an area.

It uses [QCursor](https://doc.qt.io/qt-5/qcursor.html) to set the mouse cursor position when the arrow keys are pressed ([setPos](https://doc.qt.io/qt-5/qcursor.html#setPos)). With this is is not possible to move beyond screen boundaries (at least on X11 - see below).
I've added a notice to the `SnippingAreaSelectorInfoText` class so users are aware of the feature. Let me know if I need to do something so the **translation system** works correctly.
I've also added this new feature to the two changelog files - inspired by the previous commits.

> [!IMPORTANT]
> I've only tested this on my personal machine running Linux Mint 21.3 Cinnamon (X11) with Qt 5.15.2. I don't know how the Qt Mouse positioning function handles other window managers.
> I am trying rn to build with Qt6 and then build the AppImage so I can test in a vm with different window managers.
>
> All the existing tests pass - as expected.

Here is a small demo video:

https://github.com/user-attachments/assets/67f89677-9391-4698-88af-18e90267d2fa

***

There may be more issues related to this but these are the ones I could find with a quick search:
Closes ksnip/ksnip#646, closes ksnip/ksnip#816, closes ksnip/ksnip#887, closes ksnip/ksnip#1002