### PR TITLE
Fix #1132

### DIFF
--- a/src/gui/snippingArea/X11SnippingArea.cpp
+++ b/src/gui/snippingArea/X11SnippingArea.cpp
@@ -45,8 +45,8 @@ QRect X11SnippingArea::selectedRectArea() const
 
 void X11SnippingArea::setFullScreen()
 {
-    setFixedSize(QGuiApplication::primaryScreen()->size());
-    QWidget::showFullScreen();
+    setGeometry(mDesktopGeometry.toRect());
+    QWidget::show();
 }
 
 QSizeF X11SnippingArea::getSize() const


### PR DESCRIPTION
Fixes a issue in upgrading from QT5 to QT6. Which causes the snippet area to not be on the correct monitor.
As described in #1132 