### PR TITLE
Upgrade macOS runner from 13 to 14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-macos:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
 
   package-dmg:
     if: ${{ github.event_name == 'push' }}
-    runs-on: macos-13
+    runs-on: macos-14
     needs: test-macos
     steps:
       - name: Checkout


### PR DESCRIPTION
The macOS-13 based runner images are now retired.

https://github.com/actions/runner-images/issues/13046