### PR TITLE
Wayland portal integration and capture modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Release 1.11.0
 * New: Allow pixel based adjustments via arrow keys when capturing an area. ([#646](https://github.com/ksnip/ksnip/issues/646), [#816](https://github.com/ksnip/ksnip/issues/816), [#887](https://github.com/ksnip/ksnip/issues/887), [#1002](https://github.com/ksnip/ksnip/issues/1002))
+* New: Enabled additional capture modes (RectArea, ActiveWindow, etc.) for Wayland and KDE Wayland backends.
+
 * Fixed: Cannot compile from source, kImageAnnotatorConfig not found despite being built and installed. ([#1027](https://github.com/ksnip/ksnip/issues/1027))
 * Fixed: Impossible to use by multiple users on the same machine. ([#975](https://github.com/ksnip/ksnip/issues/975))
 * New kImageAnnotator: Allow copying items between tabs. ([#318](https://github.com/ksnip/kImageAnnotator/issues/318))

--- a/src/backend/imageGrabber/KdeWaylandImageGrabber.cpp
+++ b/src/backend/imageGrabber/KdeWaylandImageGrabber.cpp
@@ -62,6 +62,8 @@ static QImage readImage(int pipeFd)
 
 KdeWaylandImageGrabber::KdeWaylandImageGrabber(const QSharedPointer<IConfig> &config) : AbstractImageGrabber(config)
 {
+	addSupportedCaptureMode(CaptureModes::RectArea);
+	addSupportedCaptureMode(CaptureModes::ActiveWindow);
 	addSupportedCaptureMode(CaptureModes::WindowUnderCursor);
 	addSupportedCaptureMode(CaptureModes::CurrentScreen);
 	addSupportedCaptureMode(CaptureModes::FullScreen);
@@ -73,6 +75,8 @@ void KdeWaylandImageGrabber::grab()
         prepareDBus(QLatin1String("screenshotFullscreen"), isCaptureCursorEnabled());
     } else if (captureMode() == CaptureModes::CurrentScreen) {
         prepareDBus(QLatin1String("screenshotScreen"), isCaptureCursorEnabled());
+    } else if (captureMode() == CaptureModes::ActiveWindow) {
+        prepareDBus(QLatin1String("screenshotWindow"), isCaptureCursorEnabled());
     } else {
         int mask = 1;
         if (isCaptureCursorEnabled()) {

--- a/src/backend/imageGrabber/WaylandImageGrabber.cpp
+++ b/src/backend/imageGrabber/WaylandImageGrabber.cpp
@@ -23,9 +23,13 @@ WaylandImageGrabber::WaylandImageGrabber(const QSharedPointer<IConfig> &config) 
 	AbstractImageGrabber(config),
 	mRequestTokenCounter(1)
 {
-  addSupportedCaptureMode(CaptureModes::RectArea);
+	addSupportedCaptureMode(CaptureModes::RectArea);
+	addSupportedCaptureMode(CaptureModes::LastRectArea);
+	addSupportedCaptureMode(CaptureModes::ActiveWindow);
+	addSupportedCaptureMode(CaptureModes::CurrentScreen);
+	addSupportedCaptureMode(CaptureModes::WindowUnderCursor);
 	addSupportedCaptureMode(CaptureModes::FullScreen);
-	}
+}
 
 void WaylandImageGrabber::grab()
 {


### PR DESCRIPTION
This commit enhances the Wayland and KDE Wayland backends to support a wider range of capture modes and improves the reliability of the desktop portal integration. Tested on Fedora 43

Changes:
- Enabled RectArea, ActiveWindow, and Screen capture modes for Wayland.

Edit: The previous message was from the changelog for the atomic repo ksnip packages