### PR TITLE
Fix X11 rectangular capture on multi-monitor setups

### DIFF
--- a/src/backend/imageGrabber/AbstractRectAreaImageGrabber.cpp
+++ b/src/backend/imageGrabber/AbstractRectAreaImageGrabber.cpp
@@ -109,10 +109,15 @@ QPixmap AbstractRectAreaImageGrabber::getScreenshotFromRect(const QRect &rect) c
 QPixmap AbstractRectAreaImageGrabber::getScreenshot() const
 {
 	if (isRectAreaCaptureWithBackground()) {
-		return snippingAreaBackground().copy(mCaptureRect);
+		return getScreenshotFromBackground();
 	} else {
 		return getScreenshotFromRect(mCaptureRect);
 	}
+}
+
+QPixmap AbstractRectAreaImageGrabber::getScreenshotFromBackground() const
+{
+	return snippingAreaBackground().copy(mCaptureRect);
 }
 
 void AbstractRectAreaImageGrabber::setCaptureRectFromCorrectSource()

--- a/src/backend/imageGrabber/AbstractRectAreaImageGrabber.h
+++ b/src/backend/imageGrabber/AbstractRectAreaImageGrabber.h
@@ -48,6 +48,7 @@ protected:
 	QPixmap snippingAreaBackground() const;
 	QPixmap getScreenshotFromRect(const QRect &rect) const;
 	QPixmap getScreenshot() const;
+	virtual QPixmap getScreenshotFromBackground() const;
 	void setCaptureRectFromCorrectSource();
 	virtual bool isSnippingAreaBackgroundTransparent() const;
 	virtual CursorDto getCursorWithPosition() const = 0;

--- a/src/backend/imageGrabber/BaseX11ImageGrabber.cpp
+++ b/src/backend/imageGrabber/BaseX11ImageGrabber.cpp
@@ -57,3 +57,9 @@ CursorDto BaseX11ImageGrabber::getCursorWithPosition() const
 {
 	return mX11Wrapper->getCursorWithPosition();
 }
+
+QPixmap BaseX11ImageGrabber::getScreenshotFromBackground() const
+{
+	auto copyRect = mCaptureRect.translated(-fullScreenRect().topLeft());
+	return snippingAreaBackground().copy(mHdpiScaler.scale(copyRect));
+}

--- a/src/backend/imageGrabber/BaseX11ImageGrabber.h
+++ b/src/backend/imageGrabber/BaseX11ImageGrabber.h
@@ -37,6 +37,7 @@ protected:
 	QRect activeWindowRect() const override;
 	bool isSnippingAreaBackgroundTransparent() const override;
 	CursorDto getCursorWithPosition() const override;
+	QPixmap getScreenshotFromBackground() const override;
 
 private:
     X11Wrapper *mX11Wrapper;

--- a/src/gui/snippingArea/AbstractSnippingArea.cpp
+++ b/src/gui/snippingArea/AbstractSnippingArea.cpp
@@ -79,6 +79,12 @@ QRect AbstractSnippingArea::getCaptureArea() const
     return anAuto;
 }
 
+QRect AbstractSnippingArea::getGlobalCaptureArea() const
+{
+	auto captureArea = getCaptureArea();
+	return { mapToGlobal(captureArea.topLeft()), captureArea.size() };
+}
+
 void AbstractSnippingArea::showSnippingArea()
 {
 	startTimeout();

--- a/src/gui/snippingArea/AbstractSnippingArea.h
+++ b/src/gui/snippingArea/AbstractSnippingArea.h
@@ -68,6 +68,7 @@ protected:
 	virtual QRectF getGeometry() const;
 	virtual void showSnippingArea();
 	QRect getCaptureArea() const;
+	QRect getGlobalCaptureArea() const;
 
 private:
     QRect mCaptureArea;

--- a/src/gui/snippingArea/WaylandSnippingArea.h
+++ b/src/gui/snippingArea/WaylandSnippingArea.h
@@ -21,6 +21,7 @@
 #define KSNIP_WAYLANDSNIPPINGAREA_H
 
 #include "X11SnippingArea.h"
+#include "src/common/platform/HdpiScaler.h"
 
 class WaylandSnippingArea : public X11SnippingArea
 {

--- a/src/gui/snippingArea/X11SnippingArea.cpp
+++ b/src/gui/snippingArea/X11SnippingArea.cpp
@@ -19,6 +19,7 @@
 
 #include "X11SnippingArea.h"
 #include <QGuiApplication>
+#include <QScreen>
 
 X11SnippingArea::X11SnippingArea(const QSharedPointer<IConfig> &config) :
 	AbstractSnippingArea(config),
@@ -34,13 +35,7 @@ X11SnippingArea::X11SnippingArea(const QSharedPointer<IConfig> &config) :
 
 QRect X11SnippingArea::selectedRectArea() const
 {
-    auto captureArea = getCaptureArea();
-
-    if(isBackgroundTransparent()) {
-		return captureArea;
-	} else {
-        return mHdpiScaler.scale(captureArea);
-	}
+	return getGlobalCaptureArea();
 }
 
 void X11SnippingArea::setFullScreen()

--- a/src/gui/snippingArea/X11SnippingArea.h
+++ b/src/gui/snippingArea/X11SnippingArea.h
@@ -21,7 +21,6 @@
 #define KSNIP_X11SNIPPINGAREA_H
 
 #include "AbstractSnippingArea.h"
-#include "src/common/platform/HdpiScaler.h"
 
 class X11SnippingArea : public AbstractSnippingArea
 {
@@ -37,7 +36,6 @@ protected:
 
 private:
 	QRectF mDesktopGeometry;
-	HdpiScaler mHdpiScaler;
 	bool mIsDesktopGeometryCalculated;
 
 	void calculateDesktopGeometry();


### PR DESCRIPTION
Rectangular captures on X11 used the selection rectangle from the snipping overlay as if it were already in global desktop coordinates. This is wrong when the overlay spans a virtual desktop whose origin is not (0, 0), for example when a secondary monitor is placed left or above the primary screen. In that case ksnip can grab a shifted or unrelated area even though the selection UI is drawn in the expected place.

Convert the selected snipping rectangle to global widget coordinates via mapToGlobal() before handing it to the image grabber. For the frozen-background path, keep the final capture rectangle global for consistency with last-rect/current-rect handling, but translate it back relative to the full-screen background pixmap before copying from that pixmap.

This keeps the generic background-copy behavior unchanged for other platforms while letting the X11 grabber handle the extra virtual-desktop offset explicitly. The Wayland header now includes HdpiScaler directly because it no longer receives that type transitively through X11SnippingArea.

Verified by building ksnip with CMake and launching the binary with --version. Also manually checked rectangular capture on a multi-monitor setup.