### PR TITLE
Fix desktop file name warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
     app.setOrganizationDomain(QLatin1String("ksnip.ksnip.org"));
     app.setApplicationName(QLatin1String("ksnip"));
     app.setApplicationVersion(QLatin1String(KSNIP_VERSION));
-    app.setDesktopFileName(QLatin1String("org.ksnip.ksnip.desktop"));
+    app.setDesktopFileName(QLatin1String("org.ksnip.ksnip"));
 
     auto dependencyInjector = new DependencyInjector;
 	DependencyInjectorBootstrapper::BootstrapCore(dependencyInjector);


### PR DESCRIPTION
## Summary

- pass the desktop entry base name to `QGuiApplication::setDesktopFileName`
- avoid the startup warning caused by the trailing `.desktop` suffix

## Root cause

`QGuiApplication::setDesktopFileName` expects the desktop entry's base name without the `.desktop` extension. ksnip passed the complete file name, so newer Qt versions removed the suffix and emitted a warning.

## Validation

- `cmake --build build-tests --config Release --parallel 4 --target ksnip`
- `ctest --test-dir build-tests/tests -C Release --output-on-failure` (10/10 tests passed)
- launched `ksnip --version` successfully without the desktop file name warning

Fixes #1174
