### PR TITLE
Fix plugin instance ownership

### DIFF
--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -39,7 +39,9 @@ void PluginManager::loadPlugins()
 	auto pluginInfos = mConfig->pluginInfos();
 
 	for (const auto& pluginInfo : pluginInfos) {
-		auto plugin = QSharedPointer<QObject>(mLoader->load(pluginInfo.path()));
+		auto pluginInstance = mLoader->load(pluginInfo.path());
+		// QPluginLoader owns the root instance and deletes it when the plugin is unloaded.
+		auto plugin = QSharedPointer<QObject>(pluginInstance, [](QObject *) {});
 		if(plugin.isNull()) {
 			mLogger->log(QString("Unable to load plugin %1 of type %2").arg(pluginInfo.path(), EnumTranslator::instance()->toString(pluginInfo.type())));
 		} else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UNITTEST_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/gui/captureHandler/SingleCaptureHandlerTests.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/gui/operations/DeleteImageOperationTests.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/gui/operations/LoadImageFromFileOperationTests.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/plugins/PluginManagerTests.cpp
 	)
 
 set(TESTUTILS_SRC
@@ -32,7 +33,8 @@ set(TESTUTILS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/mocks/gui/clipboard/ClipboardMock.h
 	${CMAKE_CURRENT_SOURCE_DIR}/mocks/gui/captureHandler/CaptureTabStateHandlerMock.h
 	${CMAKE_CURRENT_SOURCE_DIR}/mocks/common/loader/IconLoaderMock.h
-	${CMAKE_CURRENT_SOURCE_DIR}/mocks/common/platform/CommandRunnerMock.h)
+	${CMAKE_CURRENT_SOURCE_DIR}/mocks/common/platform/CommandRunnerMock.h
+	${CMAKE_CURRENT_SOURCE_DIR}/mocks/plugins/PluginLoaderMock.h)
 
 add_library(KSNIP_STATIC ${KSNIP_SRCS})
 

--- a/tests/mocks/plugins/PluginLoaderMock.h
+++ b/tests/mocks/plugins/PluginLoaderMock.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Xie Zhuoyang
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KSNIP_PLUGINLOADERMOCK_H
+#define KSNIP_PLUGINLOADERMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "src/plugins/IPluginLoader.h"
+
+class PluginLoaderMock : public IPluginLoader
+{
+public:
+	MOCK_METHOD(QObject*, load, (const QString &path), (const, override));
+};
+
+#endif //KSNIP_PLUGINLOADERMOCK_H

--- a/tests/plugins/PluginManagerTests.cpp
+++ b/tests/plugins/PluginManagerTests.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Xie Zhuoyang
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "PluginManagerTests.h"
+
+#include <QPointer>
+
+#include "src/logging/NoneLogger.h"
+#include "src/plugins/PluginManager.h"
+
+#include "tests/mocks/backend/config/ConfigMock.h"
+#include "tests/mocks/plugins/PluginLoaderMock.h"
+#include "tests/utils/TestRunner.h"
+
+void PluginManagerTests::Destructor_Should_NotDeletePlugin_When_PluginLoaderOwnsInstance()
+{
+	// arrange
+	auto pluginInfo = PluginInfo(PluginType::Ocr, QLatin1String("1.0"), QLatin1String("/plugins/ocr"));
+	QObject plugin;
+	auto guardedPlugin = QPointer<QObject>(&plugin);
+	auto configMock = QSharedPointer<ConfigMock>(new ConfigMock);
+	auto pluginLoaderMock = QSharedPointer<PluginLoaderMock>(new PluginLoaderMock);
+	auto logger = QSharedPointer<NoneLogger>(new NoneLogger);
+
+	EXPECT_CALL(*configMock, pluginInfos())
+			.WillOnce(testing::Return(QList<PluginInfo>{ pluginInfo }));
+
+	EXPECT_CALL(*pluginLoaderMock, load(pluginInfo.path()))
+			.WillOnce(testing::Return(&plugin));
+
+	// act
+	{
+		PluginManager pluginManager(configMock, pluginLoaderMock, logger);
+
+		// assert
+		QCOMPARE(pluginManager.get(PluginType::Ocr).data(), &plugin);
+	}
+
+	// assert
+	QCOMPARE(guardedPlugin.data(), &plugin);
+}
+
+void PluginManagerTests::LoadPlugins_Should_NotDeletePlugin_When_LoaderReturnsSameInstanceTwice()
+{
+	// arrange
+	auto firstPluginInfo = PluginInfo(PluginType::Ocr, QLatin1String("1.0"), QLatin1String("/usr/lib/plugin.so"));
+	auto secondPluginInfo = PluginInfo(PluginType::Ocr, QLatin1String("1.0"), QLatin1String("/usr/lib64/plugin.so"));
+	QObject plugin;
+	auto guardedPlugin = QPointer<QObject>(&plugin);
+	auto configMock = QSharedPointer<ConfigMock>(new ConfigMock);
+	auto pluginLoaderMock = QSharedPointer<PluginLoaderMock>(new PluginLoaderMock);
+	auto logger = QSharedPointer<NoneLogger>(new NoneLogger);
+
+	EXPECT_CALL(*configMock, pluginInfos())
+			.WillOnce(testing::Return(QList<PluginInfo>{ firstPluginInfo, secondPluginInfo }));
+
+	EXPECT_CALL(*pluginLoaderMock, load(testing::_))
+			.Times(2)
+			.WillRepeatedly(testing::Return(&plugin));
+
+	// act
+	{
+		PluginManager pluginManager(configMock, pluginLoaderMock, logger);
+
+		// assert
+		QCOMPARE(pluginManager.get(PluginType::Ocr).data(), &plugin);
+	}
+
+	// assert
+	QCOMPARE(guardedPlugin.data(), &plugin);
+}
+
+TEST_MAIN(PluginManagerTests)

--- a/tests/plugins/PluginManagerTests.h
+++ b/tests/plugins/PluginManagerTests.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Xie Zhuoyang
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KSNIP_PLUGINMANAGERTESTS_H
+#define KSNIP_PLUGINMANAGERTESTS_H
+
+#include <QtTest>
+
+class PluginManagerTests : public QObject
+{
+	Q_OBJECT
+private slots:
+	void Destructor_Should_NotDeletePlugin_When_PluginLoaderOwnsInstance();
+	void LoadPlugins_Should_NotDeletePlugin_When_LoaderReturnsSameInstanceTwice();
+};
+
+#endif //KSNIP_PLUGINMANAGERTESTS_H


### PR DESCRIPTION
## Summary

- keep plugin root instances as non-owning shared references
- avoid deleting objects managed by `QPluginLoader`
- add regression coverage for manager destruction and duplicate plugin discovery

## Root cause

`QPluginLoader::instance()` owns the plugin root object and deletes it when the plugin is unloaded. `PluginManager` wrapped the raw pointer in an owning `QSharedPointer`, so replacing a plugin entry—such as when `/usr/lib` and `/usr/lib64` resolve to the same plugin—deleted the shared root instance and left a dangling pointer that could be deleted again.

## Validation

- Debug: `ctest --test-dir build-tests/tests -C Debug --output-on-failure` (11/11 passed)
- Release: `ctest --test-dir build-tests/tests -C Release --output-on-failure` (11/11 passed)
- Release application target built successfully and `ksnip --version` exited successfully

Fixes #1108
