### PR TITLE
Fix: "Print to File" pre-checked by default on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![IRC: #ksnip on libera.chat][libera-badge]][libera-badge-url]
 [![GitHub license](https://img.shields.io/github/license/ksnip/ksnip?color=lightgrey)](https://github.com/ksnip/ksnip/blob/master/LICENSE.txt)
 
-Version v1.11.0
+Version v1.11.0 
 
 Ksnip is a Qt-based cross-platform screenshot tool that provides many annotation features
 for your screenshots.

--- a/src/backend/CapturePrinter.cpp
+++ b/src/backend/CapturePrinter.cpp
@@ -26,8 +26,8 @@ CapturePrinter::CapturePrinter(QWidget *parent) : mParent(parent)
 
 void CapturePrinter::print(const QImage &image, const QString &defaultPath)
 {
+    Q_UNUSED(defaultPath)
     QPrinter printer;
-    printer.setOutputFileName(defaultPath);
     printer.setOutputFormat(QPrinter::NativeFormat);
     QPrintDialog printDialog(&printer, mParent);
 

--- a/src/backend/CapturePrinter.cpp
+++ b/src/backend/CapturePrinter.cpp
@@ -55,8 +55,8 @@ void CapturePrinter::printCapture(const QImage &image, QPrinter *p)
 
 void CapturePrinter::printPreview(const QImage &image, const QString &defaultPath)
 {
+    Q_UNUSED(defaultPath)
     QPrinter printer;
-    printer.setOutputFileName(defaultPath);
     printer.setOutputFormat(QPrinter::NativeFormat);
     QPrintPreviewDialog printDialog(&printer, mParent, Qt::Window | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);
 	connect(&printDialog, &QPrintPreviewDialog::paintRequested, [this, image](QPrinter *p)

--- a/src/backend/CapturePrinter.cpp
+++ b/src/backend/CapturePrinter.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "CapturePrinter.h"
-#include <QDebug>
 
 CapturePrinter::CapturePrinter(QWidget *parent) : mParent(parent)
 {
@@ -30,7 +29,6 @@ void CapturePrinter::print(const QImage &image, const QString &defaultPath)
     Q_UNUSED(defaultPath)
     QPrinter printer;
     printer.setOutputFormat(QPrinter::NativeFormat);
-	qDebug() << "PRINT-DEBUG outputFileName=" << printer.outputFileName() << "outputFormat=" << printer.outputFormat() << "printerName=" << printer.printerName();
     QPrintDialog printDialog(&printer, mParent);
 
     if (printDialog.exec() == QDialog::Accepted) {

--- a/src/backend/CapturePrinter.cpp
+++ b/src/backend/CapturePrinter.cpp
@@ -29,6 +29,7 @@ void CapturePrinter::print(const QImage &image, const QString &defaultPath)
     Q_UNUSED(defaultPath)
     QPrinter printer;
     printer.setOutputFormat(QPrinter::NativeFormat);
+	qDebug() << "PRINT-DEBUG outputFileName=" << printer.outputFileName() << "outputFormat=" << printer.outputFormat() << "printerName=" << printer.printerName();
     QPrintDialog printDialog(&printer, mParent);
 
     if (printDialog.exec() == QDialog::Accepted) {

--- a/src/backend/CapturePrinter.cpp
+++ b/src/backend/CapturePrinter.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "CapturePrinter.h"
+#include <QDebug>
 
 CapturePrinter::CapturePrinter(QWidget *parent) : mParent(parent)
 {


### PR DESCRIPTION
Addresses the problem described in discussion #1111 — the "Print to File" checkbox in the print dialog is checked by default on Windows, regardless of the selected printer or Windows print settings.

## Root cause
`CapturePrinter::print()` and `CapturePrinter::printPreview()` call `printer.setOutputFileName(defaultPath)` with a real `.pdf` path before opening `QPrintDialog`, even though `printer.setOutputFormat(QPrinter::NativeFormat)` is called immediately after. On Windows, Qt 5.15.2's `qprintengine_win.cpp` sets an internal `printToFile` flag to `true` in its `PPK_OutputFileName` property handler for any non-empty filename, regardless of the subsequent `setOutputFormat()` call. This flag directly drives the `PD_PRINTTOFILE` native dialog flag that pre-checks "Print to File".

## Fix
Removed the `setOutputFileName()` calls before showing the dialog. `defaultPath` is kept as a parameter (now unused, marked with `Q_UNUSED`) to avoid a larger API change — happy to remove it entirely if preferred.

## Cross-platform impact
- **Windows**: fixes the described bug (tested with a custom build).
- **Linux/Unix** (`qprintdialog_unix.cpp`, CUPS): the analogous "Print to File" pre-selection is driven by `outputFormat() == QPrinter::PdfFormat`, not by a non-empty `outputFileName()`, and `outputFormat` is reset to `NativeFormat` by the very next line regardless of this change — so this should have no functional effect on Linux, before or after.
- **macOS** (`qprintengine_mac.mm`): `PPK_OutputFileName` is only stored (`d->outputFilename = value.toString()`), no side effect on the dialog's default state — unaffected by this change.
- All platforms: minor cosmetic side effect — the print-to-file save dialog no longer pre-fills a suggested filename if a user deliberately chooses to print to a file.

Windows behavior verified with a custom CI build from this branch; Linux/macOS impact assessed from source only, not tested on real hardware — feedback welcome.