### PR TITLE
Fix multi-monitor capture shifted by primary screen position

### DIFF
--- a/src/backend/imageGrabber/AbstractRectAreaImageGrabber.cpp
+++ b/src/backend/imageGrabber/AbstractRectAreaImageGrabber.cpp
@@ -22,6 +22,9 @@
 #include <QDesktopWidget>
 #endif
 
+#include <QPainter>
+#include <QScreen>
+
 AbstractRectAreaImageGrabber::AbstractRectAreaImageGrabber(AbstractSnippingArea *snippingArea, const QSharedPointer<IConfig> &config) :
 	AbstractImageGrabber(config),
 	mSnippingArea(snippingArea),
@@ -96,14 +99,37 @@ QPixmap AbstractRectAreaImageGrabber::snippingAreaBackground() const
 
 QPixmap AbstractRectAreaImageGrabber::getScreenshotFromRect(const QRect &rect) const
 {
-	auto screen = QGuiApplication::primaryScreen();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	auto windowId = 0;
+	// QScreen::grabWindow() interprets its coordinates relative to the screen
+	// it is called on, not relative to the virtual desktop. Passing virtual
+	// desktop coordinates to the primary screen therefore offsets the whole
+	// grab by that screen's position, which on a multi-monitor setup shifts
+	// the captured image sideways. Grab each screen at its own origin instead
+	// and compose them at their virtual desktop positions.
+	QPixmap composed(rect.size());
+	composed.fill(Qt::transparent);
+
+	QPainter painter(&composed);
+	for (auto screen : QGuiApplication::screens()) {
+		auto screenGeometry = screen->geometry();
+		auto intersection = screenGeometry.intersected(rect);
+		if (intersection.isEmpty()) {
+			continue;
+		}
+
+		auto source = intersection.translated(-screenGeometry.topLeft());
+		auto grabbed = screen->grabWindow(0, source.x(), source.y(), source.width(), source.height());
+		painter.drawPixmap(intersection.topLeft() - rect.topLeft(), grabbed);
+	}
+	painter.end();
+
+	return composed;
 #else
+	auto screen = QGuiApplication::primaryScreen();
 	auto windowId = QApplication::desktop()->winId();
-#endif
 	auto rectPosition = rect.topLeft();
 	return screen->grabWindow(windowId, rectPosition.x(), rectPosition.y(), rect.width(), rect.height());
+#endif
 }
 
 QPixmap AbstractRectAreaImageGrabber::getScreenshot() const


### PR DESCRIPTION
`QScreen::grabWindow()` interprets its x/y arguments relative to the screen it is called on, not relative to the virtual desktop. `getScreenshotFromRect()` passes virtual desktop coordinates to the primary screen, so when that screen is not at the virtual desktop origin the entire grab is displaced by its position.

On my setup (eDP 2880x1920+0+0, DisplayPort-1 5120x2160+2880+0, primary DisplayPort-1) the captured desktop lands 2880px to the left, so a selection made on the right hand monitor returns content from the left hand one.

Two checks on the grab returned for the full 8000x2160 desktop. The region x<2880 y>1920 falls outside every monitor and should be blank, but held 9832 distinct colours of real content. DisplayPort-1's leftmost column appeared at x=0 instead of x=2880. After the fix that off-screen region is a single uniform colour.

This looks like the cause of #1177 and #1120. #1177 was reported against a build that already contained #1164, which matches what I see: #1164 is in my build and the shift remains.

The Qt5 path is unchanged, since there the grab goes through the desktop widget's window id, which really is rooted at the virtual desktop origin.

Tested on openSUSE Tumbleweed, Qt 6.11.1, X11/XFCE with the two monitors above. I have no way to test macOS or Windows, which share this code path through the Qt6 branch.